### PR TITLE
Add advanced analytics pipeline modules

### DIFF
--- a/run_pipeline_advanced.py
+++ b/run_pipeline_advanced.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from src.atlas_advanced import (
+    fdr_significance,
+    granger_pvals,
+    lead_lag,
+    nl_summary,
+    partial_corr,
+)
+from src.db import connect
+from src.harvest import harvest
+from src.mapping_beta import (
+    build_portfolio_weights,
+    local_projection_beta,
+    summarize_tilt,
+)
+from src.models_advanced import fit_dfm, fit_svar, fit_var, irf_svar, irf_var
+from src.normalize import normalize_latest_snapshot
+from src.report import render_report
+from src.scenario_dsl import apply as apply_scen
+from src.scenario_dsl import load as load_scen
+
+
+
+def wide_from_obs(limit: int = 300):
+    con = connect()
+    df = con.execute("SELECT series_key, period, value FROM obs").df()
+    df["logical_name"] = df["series_key"].str.split("|").str[0]
+    lens = df.groupby("logical_name")["period"].nunique().sort_values(ascending=False)
+    keep = lens.head(limit).index
+    piv = (
+        df[df["logical_name"].isin(keep)]
+        .pivot_table(index="period", columns="logical_name", values="value")
+        .sort_index()
+    )
+    return piv.interpolate(limit_direction="both")
+
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--series-yaml", default="series.yaml")
+    ap.add_argument("--mode", choices=["full", "update"], default="update")
+    ap.add_argument("--scenario", default=None)
+    ap.add_argument("--report", default="out/report.md")
+    ap.add_argument("--shock-col", default="macro.policy_rate", help="β 추정용 충격 컬럼명")
+    ap.add_argument("--asset-prefix", default="asset.", help="자산 시리즈 접두어 (obs.series_key 기준)")
+    args = ap.parse_args()
+
+    Path("out").mkdir(exist_ok=True)
+
+    harvest(args.series_yaml, mode=args.mode)
+    normalize_latest_snapshot()
+
+    wide = wide_from_obs(limit=300)
+    Z = wide.dropna(axis=1, how="any")
+    if Z.shape[1] < 3:
+        raise RuntimeError("시리즈가 너무 적습니다. series.yaml에 추가하세요.")
+
+    pc = partial_corr(Z)
+    gp = granger_pvals(Z, maxlag=4)
+    gp_sig = fdr_significance(gp, alpha=0.05)
+    ll = lead_lag(Z, max_lag=6)
+    bullets = nl_summary(pc, gp_sig, ll, top_n=5)
+
+    core = list(Z.columns[:6])
+    var_res = fit_var(Z[core], lags=2)
+    irf_v = irf_var(var_res, periods=8)
+    try:
+        svar_res = fit_svar(Z[core], lags=2)
+        irf_s = irf_svar(svar_res, periods=8)
+        irf_use = irf_s
+    except Exception:
+        irf_use = irf_v
+
+    target = [c for c in Z.columns if c.endswith("gdp_growth")]
+    if target:
+        try:
+            dfm = fit_dfm(Z[target + core].dropna(), k_factors=1, error_order=1)
+        except Exception:
+            pass
+
+    if args.scenario and Path(args.scenario).exists():
+        scen = load_scen(args.scenario)
+    else:
+        scen = {
+            "horizon_quarters": 8,
+            "shocks": {args.shock_col: {"type": "step", "value": 0.5}},
+        }
+    resp = apply_scen(irf_use, core, scen)
+
+    asset_cols = [c for c in Z.columns if c.startswith(args.asset_prefix)]
+    beta_df = pd.DataFrame()
+    ow, uw = pd.DataFrame(), pd.DataFrame()
+    if asset_cols and args.shock_col in Z.columns:
+        betas = local_projection_beta(
+            Z[[args.shock_col] + asset_cols],
+            args.shock_col,
+            asset_cols,
+            horizons=(1, 4, 8),
+        )
+        beta_df = pd.DataFrame({a: betas[a] for a in betas}).T
+        ow, uw = summarize_tilt(betas, horizon=4, top=8)
+        weights = build_portfolio_weights(pd.concat([ow, uw]))
+        weights.to_csv("out/portfolio_weights.csv")
+    else:
+        weights = pd.Series(dtype=float)
+
+    inv_df = pd.DataFrame(columns=["asset", "score", "stance"])
+    if not ow.empty or not uw.empty:
+        tmp = pd.concat(
+            [
+                ow.assign(score=ow.filter(like="beta_").max(axis=1).values),
+                uw.assign(score=uw.filter(like="beta_").max(axis=1).values),
+            ]
+        )
+        tmp["stance"] = tmp["stance"].astype(str)
+        inv_df = tmp[["asset", "score", "stance"]].reset_index(drop=True)
+    render_report(
+        args.report,
+        bullets,
+        inv_df
+        if not inv_df.empty
+        else pd.DataFrame(
+            [
+                {"asset": "(샘플) banks", "score": 0.1, "stance": "Overweight"},
+                {"asset": "(샘플) growth_stocks", "score": -0.1, "stance": "Underweight"},
+            ]
+        ),
+    )
+    print(
+        f"[advanced] report → {args.report}; weights(out/portfolio_weights.csv) rows={len(weights)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scenarios/advanced_example.yaml
+++ b/scenarios/advanced_example.yaml
@@ -1,0 +1,8 @@
+name: "금리 +50bp (2Q 유지) + 인구 -5% 점진"
+horizon_quarters: 12
+shocks:
+  macro.population_total:
+    type: gradual
+    value: "-5%"
+policy_path:
+  macro.policy_rate: [0.5, 0.5, 0.25, 0.0, -0.25, 0.0]

--- a/src/atlas_advanced.py
+++ b/src/atlas_advanced.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import itertools
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from statsmodels.stats.multitest import multipletests
+from statsmodels.tsa.stattools import ccf, grangercausalitytests
+
+
+def partial_corr(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute partial correlations from precision matrix."""
+    X = (df - df.mean()) / df.std(ddof=0)
+    X = X.dropna(axis=1, how="any").dropna()
+    S = np.cov(X.values, rowvar=False)
+    P = np.linalg.pinv(S)
+    d = np.sqrt(np.diag(P))
+    pcorr = -P / np.outer(d, d)
+    np.fill_diagonal(pcorr, 1.0)
+    return pd.DataFrame(pcorr, index=X.columns, columns=X.columns)
+
+
+def lead_lag(df: pd.DataFrame, max_lag: int = 6) -> pd.DataFrame:
+    """Cross-correlation-based lead/lag matrix."""
+    cols = df.columns
+    out = pd.DataFrame(0, index=cols, columns=cols, dtype=int)
+    Z = df.dropna()
+    for a, b in itertools.permutations(cols, 2):
+        x, y = Z[a].values, Z[b].values
+        c = ccf(x - np.mean(x), y - np.mean(y))[: max_lag + 1]
+        lag = int(np.argmax(np.abs(c)))
+        out.loc[a, b] = lag
+    return out
+
+
+def granger_pvals(df: pd.DataFrame, maxlag: int = 4) -> pd.DataFrame:
+    cols = df.columns
+    p = pd.DataFrame(np.nan, index=cols, columns=cols)
+    Z = df.dropna()
+    for a, b in itertools.permutations(cols, 2):
+        try:
+            res = grangercausalitytests(Z[[b, a]], maxlag=maxlag, verbose=False)
+            p.loc[a, b] = min(r[0]["ssr_ftest"][1] for r in res.values())
+        except Exception:
+            pass
+    return p
+
+
+def fdr_significance(pmat: pd.DataFrame, alpha: float = 0.05) -> pd.DataFrame:
+    vals = pmat.values.flatten()
+    mask = ~np.isnan(vals)
+    rej = np.zeros_like(vals, dtype=bool)
+    if mask.sum():
+        rej[mask] = multipletests(vals[mask], alpha=alpha, method="fdr_bh")[0]
+    return pd.DataFrame(rej.reshape(pmat.shape), index=pmat.index, columns=pmat.columns)
+
+
+def build_network(
+    corr: pd.DataFrame,
+    granger_sig: pd.DataFrame,
+    leadlag: pd.DataFrame,
+    corr_thr: float = 0.3,
+) -> nx.DiGraph:
+    """Create network combining correlations and Granger causality."""
+    G = nx.DiGraph()
+    for v in corr.columns:
+        G.add_node(v)
+    for i, a in enumerate(corr.columns):
+        for j, b in enumerate(corr.columns):
+            if i == j:
+                continue
+            g_val = granger_sig.loc[a, b] if a in granger_sig.index and b in granger_sig.columns else False
+            g_flag = bool(g_val) if pd.notna(g_val) else False
+            if abs(corr.loc[a, b]) >= corr_thr or g_flag:
+                w = float(corr.loc[a, b])
+                lag = (
+                    int(leadlag.loc[a, b])
+                    if (a in leadlag.index and b in leadlag.columns)
+                    else 0
+                )
+                G.add_edge(a, b, weight=w, lag=lag)
+    return G
+
+
+def nl_summary(
+    corr: pd.DataFrame,
+    granger_sig: pd.DataFrame,
+    leadlag: pd.DataFrame,
+    top_n: int = 5,
+) -> list[str]:
+    """Generate natural language bullet summary."""
+    tri = []
+    cols = corr.columns
+    for i in range(len(cols)):
+        for j in range(i + 1, len(cols)):
+            tri.append((cols[i], cols[j], corr.iloc[i, j]))
+    tri = sorted(tri, key=lambda x: abs(x[2]), reverse=True)[:top_n]
+    bullets = []
+    for a, b, r in tri:
+        lag_ab = leadlag.loc[a, b] if (a in leadlag.index and b in leadlag.columns) else 0
+        g_val = granger_sig.loc[a, b] if a in granger_sig.index and b in granger_sig.columns else False
+        g_flag = bool(g_val) if pd.notna(g_val) else False
+        sig = " (Granger 유의)" if g_flag else ""
+        bullets.append(f"{a} ↔ {b} 상관 {r:.2f}, lead/lag: {lag_ab}기{sig}")
+    return bullets

--- a/src/mapping_beta.py
+++ b/src/mapping_beta.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+
+
+def local_projection_beta(
+    df: pd.DataFrame,
+    shock_col: str,
+    asset_cols: List[str],
+    horizons: Tuple[int, ...] = (1, 4),
+):
+    out: Dict[str, Dict[int, float]] = {a: {} for a in asset_cols}
+    z = df[[shock_col] + asset_cols].dropna()
+    for a in asset_cols:
+        y = z[a].values
+        x = z[shock_col].values.reshape(-1, 1)
+        for h in horizons:
+            if len(y) <= h + 1:
+                continue
+            yt = y[h:]
+            xt = x[:-h]
+            mdl = LinearRegression().fit(xt, yt)
+            out[a][h] = float(mdl.coef_[0])
+    return out
+
+
+def summarize_tilt(
+    betas: Dict[str, Dict[int, float]],
+    horizon: int = 4,
+    top: int = 8,
+):
+    rows = []
+    for a, d in betas.items():
+        b = d.get(horizon, np.nan)
+        rows.append((a, b))
+    rows = sorted(rows, key=lambda x: (0 if np.isnan(x[1]) else -abs(x[1])))
+    out = []
+    for a, b in rows:
+        if np.isnan(b):
+            stance = "Neutral"
+        else:
+            stance = "Overweight" if b > 0 else "Underweight"
+        out.append({"asset": a, "beta_h" + str(horizon): b, "stance": stance})
+    df = pd.DataFrame(out).sort_values("beta_h" + str(horizon), ascending=False)
+    return df.head(top), df.tail(top)
+
+
+def build_portfolio_weights(tilt_df: pd.DataFrame, neutral_weight: float | None = None):
+    n = len(tilt_df)
+    if n == 0:
+        return pd.Series(dtype=float)
+    if neutral_weight is None:
+        neutral_weight = 1.0 / n
+    w = pd.Series(neutral_weight, index=tilt_df["asset"])
+    for _, r in tilt_df.iterrows():
+        if r["stance"] == "Overweight":
+            w[r["asset"]] += 0.01
+        elif r["stance"] == "Underweight":
+            w[r["asset"]] -= 0.01
+    w = (w.clip(lower=0) / w.clip(lower=0).sum()).sort_values(ascending=False)
+    return w

--- a/src/models_advanced.py
+++ b/src/models_advanced.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LassoCV
+from sklearn.preprocessing import StandardScaler
+from statsmodels.tsa.api import DynamicFactor, VAR
+from statsmodels.tsa.vector_ar.svar_model import SVAR
+
+
+def fit_var(df: pd.DataFrame, lags: int = 2):
+    return VAR(df.dropna()).fit(lags)
+
+
+def fit_svar(
+    df: pd.DataFrame,
+    lags: int = 2,
+    A: Optional[np.ndarray] = None,
+    B: Optional[np.ndarray] = None,
+):
+    """Fit a simple SVAR model with optional identification matrices."""
+    base = VAR(df.dropna()).fit(lags)
+    k = base.neqs
+    if A is None:
+        A = np.eye(k)
+    return SVAR(base, A=A, B=B).fit(maxiter=500)
+
+
+def irf_var(res, periods: int = 8):
+    return res.irf(periods)
+
+
+def irf_svar(res_svar, periods: int = 8):
+    return res_svar.irf(periods)
+
+
+def fit_dfm(df: pd.DataFrame, k_factors: int = 1, error_order: int = 1):
+    Z = df.dropna()
+    model = DynamicFactor(
+        Z,
+        k_factors=k_factors,
+        factor_order=error_order,
+        enforce_stationarity=False,
+    )
+    res = model.fit(method="em", disp=False, maxiter=200)
+    return res
+
+
+def ml_nowcast(df_features: pd.DataFrame, y: pd.Series):
+    X, y2 = df_features.align(y, join="inner", axis=0)
+    X = X.fillna(method="ffill").fillna(0.0)
+    sc = StandardScaler()
+    Xs = sc.fit_transform(X.values)
+    mdl = LassoCV(cv=5, alphas=None, max_iter=5000, n_jobs=-1).fit(Xs, y2.values)
+    return mdl, sc

--- a/src/scenario_dsl.py
+++ b/src/scenario_dsl.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+import yaml
+
+
+def _parse_value(v):
+    if isinstance(v, str) and v.endswith("%"):
+        return float(v.strip("%")) / 100.0
+    return float(v)
+
+
+def _shock_profile(h: int, typ: str, val: float):
+    prof = np.zeros(h + 1)
+    if typ == "step":
+        prof[:] = val
+        prof[0] = val
+    elif typ == "pulse":
+        prof[0] = val
+    elif typ == "gradual":
+        for t in range(h + 1):
+            prof[t] = val * min(1.0, t / 4.0)
+    elif typ == "path":
+        raise ValueError("use policy_path for explicit path")
+    else:
+        prof[0] = val
+    return prof
+
+
+def load(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def apply(irf_obj, variables, scen: dict):
+    h = int(scen.get("horizon_quarters", 8))
+    total = np.zeros((h + 1, len(variables)))
+    orth = irf_obj.orth_irfs
+
+    for var, arr in (scen.get("policy_path") or {}).items():
+        if var not in variables:
+            continue
+        idx = variables.index(var)
+        path = np.array(arr, dtype=float)
+        for t, a in enumerate(path[: h + 1]):
+            total[t, :] += orth[t, :, idx] * a
+
+    for var, spec in (scen.get("shocks") or {}).items():
+        if var not in variables:
+            continue
+        idx = variables.index(var)
+        if isinstance(spec, dict):
+            typ = spec.get("type", "step")
+            val = _parse_value(spec.get("value", 0.0))
+        else:
+            typ = "step"
+            val = _parse_value(spec)
+        prof = _shock_profile(h, typ, val)
+        for t in range(h + 1):
+            total[t, :] += orth[t, :, idx] * prof[t]
+
+    return total


### PR DESCRIPTION
## Summary
- implement advanced atlas utilities including partial correlations, Granger FDR filters, lead/lag, and narrative bullets
- add advanced econometric models, scenario DSL application helpers, and beta mapping utilities
- create an advanced pipeline entry point with scenario example wiring atlas, models, scenario shocks, and portfolio tilts

## Testing
- python -m compileall src run_pipeline_advanced.py
- python -m compileall src/models_advanced.py

------
https://chatgpt.com/codex/tasks/task_e_68d39aa88ad0832dbc2a4bb87d265acb