### PR TITLE
Add discovery search and quad report pipeline

### DIFF
--- a/run_discovery_quad.py
+++ b/run_discovery_quad.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from src.db import connect
+from src.discovery import discover_signals
+from src.harvest import harvest
+from src.mapping_beta import local_projection_beta, summarize_tilt
+from src.normalize import normalize_latest_snapshot
+from src.report_quad import render_quad_report
+
+
+def wide_from_obs(limit: int = 500) -> pd.DataFrame:
+    con = connect()
+    df = con.execute("SELECT series_key, period, value FROM obs").df()
+    df["logical_name"] = df["series_key"].str.split("|").str[0]
+    lens = df.groupby("logical_name")["period"].nunique().sort_values(ascending=False)
+    keep = lens.head(limit).index
+    wide = (
+        df[df["logical_name"].isin(keep)]
+        .pivot_table(index="period", columns="logical_name", values="value")
+        .sort_index()
+    )
+    return wide.interpolate(limit_direction="both")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--series-yaml", default="series.yaml")
+    ap.add_argument("--mode", choices=["full", "update"], default="update")
+    ap.add_argument("--report", default="out/quad_report.md")
+    ap.add_argument("--shock-col", default="macro.policy_rate")
+    ap.add_argument("--asset-prefix", default="asset.")
+    args = ap.parse_args()
+
+    Path("out").mkdir(exist_ok=True)
+
+    harvest(args.series_yaml, mode=args.mode)
+    normalize_latest_snapshot()
+
+    wide = wide_from_obs(limit=600)
+    pairs = discover_signals(wide, corr_thr_strong=0.45, corr_thr_medium=0.3, maxlag=4)
+
+    asset_cols = [c for c in wide.columns if c.startswith(args.asset_prefix)]
+    inv_df: pd.DataFrame | None = None
+    if asset_cols and args.shock_col in wide.columns:
+        beta_df = local_projection_beta(
+            wide[[args.shock_col] + asset_cols].dropna(), args.shock_col, asset_cols, horizons=(4,)
+        )
+        ow, uw = summarize_tilt(beta_df, horizon=4, top=8)
+        inv_df = pd.concat([ow, uw], ignore_index=True)
+        inv_df = inv_df.rename(columns={inv_df.columns[1]: "score"})
+
+    render_quad_report(args.report, pairs, inv_df)
+    print(f"[discovery] report → {args.report}, pairs={len(pairs)}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/discovery.py
+++ b/src/discovery.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import itertools
+import numpy as np
+import pandas as pd
+from statsmodels.stats.multitest import multipletests
+from statsmodels.tsa.stattools import grangercausalitytests
+
+
+def _rolling_corr_consistency(df: pd.DataFrame, window: int = 20, thr: float = 0.3) -> pd.DataFrame:
+    """창 내 상관계수의 절대값이 thr 이상인 비율을 계산한다."""
+
+    cols = df.columns
+    hits = pd.DataFrame(0.0, index=cols, columns=cols)
+    total = 0
+    for end in range(window, len(df) + 1):
+        sub = df.iloc[end - window : end]
+        c = sub.corr().abs()
+        hits = hits.add((c >= thr).astype(float), fill_value=0.0)
+        total += 1
+    if total == 0:
+        return hits
+    return hits / total
+
+
+def _partial_corr(df: pd.DataFrame) -> pd.DataFrame:
+    X = (df - df.mean()) / df.std(ddof=0)
+    X = X.dropna(axis=1, how="any").dropna()
+    S = np.cov(X.values, rowvar=False)
+    P = np.linalg.pinv(S)
+    d = np.sqrt(np.diag(P))
+    pcorr = -P / np.outer(d, d)
+    np.fill_diagonal(pcorr, 1.0)
+    return pd.DataFrame(pcorr, index=X.columns, columns=X.columns)
+
+
+def _granger_pvals(df: pd.DataFrame, maxlag: int = 4) -> pd.DataFrame:
+    cols = df.columns
+    p = pd.DataFrame(np.nan, index=cols, columns=cols)
+    Z = df.dropna()
+    for a, b in itertools.permutations(cols, 2):
+        try:
+            res = grangercausalitytests(Z[[b, a]], maxlag=maxlag, verbose=False)
+            p.loc[a, b] = min(r[0]["ssr_ftest"][1] for r in res.values())
+        except Exception:
+            pass
+    return p
+
+
+def discover_signals(
+    wide: pd.DataFrame,
+    corr_thr_strong: float = 0.45,
+    corr_thr_medium: float = 0.3,
+    maxlag: int = 4,
+) -> pd.DataFrame:
+    """시계열 전수탐색으로 신호 페어를 추출한다."""
+
+    Z = wide.dropna(axis=1, how="any").dropna()
+    if Z.shape[1] < 3:
+        return pd.DataFrame()
+
+    corr = Z.corr()
+    pcorr = _partial_corr(Z).reindex_like(corr).fillna(0.0)
+    gr = _granger_pvals(Z, maxlag=maxlag)
+    flat = gr.values.flatten()
+    mask = ~np.isnan(flat)
+    rej = np.zeros_like(flat, dtype=bool)
+    if mask.sum():
+        rej[mask] = multipletests(flat[mask], alpha=0.05, method="fdr_bh")[0]
+    gr_sig = pd.DataFrame(rej.reshape(gr.shape), index=gr.index, columns=gr.columns)
+
+    def lead_of(a: pd.Series, b: pd.Series, max_lag: int = 6) -> int:
+        x = a.values - a.values.mean()
+        y = b.values - b.values.mean()
+        best, lag = 0.0, 0
+        for L in range(0, max_lag + 1):
+            if L == 0:
+                c = np.corrcoef(x, y)[0, 1]
+            else:
+                if len(x[L:]) < 5:
+                    break
+                c = np.corrcoef(x[L:], y[:-L])[0, 1]
+            if np.abs(c) > np.abs(best):
+                best, lag = c, L
+        return lag
+
+    cons = _rolling_corr_consistency(
+        Z, window=min(20, max(5, len(Z) // 5)), thr=corr_thr_medium
+    )
+
+    rows = []
+    cols = list(Z.columns)
+    for i in range(len(cols)):
+        for j in range(i + 1, len(cols)):
+            a, b = cols[i], cols[j]
+            c = corr.loc[a, b]
+            pc = pcorr.loc[a, b] if a in pcorr.index and b in pcorr.columns else np.nan
+            g_ab = bool(gr_sig.loc[a, b]) if (a in gr_sig.index and b in gr_sig.columns) else False
+            g_ba = bool(gr_sig.loc[b, a]) if (b in gr_sig.index and a in gr_sig.columns) else False
+            lag_ab = lead_of(Z[a], Z[b])
+            k = float(np.nan_to_num(pc, nan=0.0))
+            s = abs(c) + 0.5 * abs(k) + 0.2 * (g_ab + g_ba) + 0.3 * float(cons.loc[a, b])
+            tier = (
+                "strong"
+                if abs(c) >= corr_thr_strong
+                else "medium"
+                if abs(c) >= corr_thr_medium
+                else "weak"
+            )
+            rows.append(
+                {
+                    "a": a,
+                    "b": b,
+                    "corr": float(c),
+                    "pcorr": float(k),
+                    "gr_ab": g_ab,
+                    "gr_ba": g_ba,
+                    "lead_ab": int(lag_ab),
+                    "consistency": float(cons.loc[a, b]),
+                    "score": float(s),
+                    "tier": tier,
+                }
+            )
+    out = pd.DataFrame(rows).sort_values("score", ascending=False)
+    return out
+

--- a/src/report_quad.py
+++ b/src/report_quad.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pandas as pd
+
+
+def _domain(name: str) -> str:
+    n = name.lower()
+    if n.startswith("firm.") or any(
+        k in n for k in ["employment", "wage", "sales", "capex", "rd_", "industry"]
+    ):
+        return "corporate"
+    if n.startswith("asset.") or "etf" in n or "reits" in n or "bond" in n or "gold" in n:
+        return "investment"
+    if any(
+        k in n
+        for k in [
+            "policy_rate",
+            "m2",
+            "credit",
+            "loan_to_deposit",
+            "spread",
+            "npl",
+            "bank_loan",
+            "financ",
+        ]
+    ):
+        return "finance"
+    return "economy"
+
+
+def split_by_domain(pairs: pd.DataFrame) -> dict:
+    def pair_dom(a: str, b: str) -> str:
+        da, db = _domain(a), _domain(b)
+        if "investment" in (da, db):
+            return "investment"
+        if "finance" in (da, db):
+            return "finance"
+        if "corporate" in (da, db):
+            return "corporate"
+        return "economy"
+
+    pairs = pairs.copy()
+    pairs["domain"] = pairs.apply(lambda r: pair_dom(r["a"], r["b"]), axis=1)
+    return {k: v for k, v in pairs.groupby("domain")}
+
+
+def bullets_for(df: pd.DataFrame, top_strong: int = 8, top_medium: int = 5) -> list[str]:
+    strong = df[df["tier"] == "strong"].head(top_strong)
+    medium = df[df["tier"] == "medium"].head(top_medium)
+    bl: list[str] = []
+    for _, r in strong.iterrows():
+        sig = " (Granger)" if (r["gr_ab"] or r["gr_ba"]) else ""
+        bl.append(
+            f"**{r['a']}** ↔ **{r['b']}**: 상관 {r['corr']:.2f}, 지속률 {r['consistency']:.2f}{sig}"
+        )
+    if len(medium):
+        bl.append("_준유의 신호_")
+        for _, r in medium.iterrows():
+            bl.append(
+                f"- {r['a']} ↔ {r['b']}: 상관 {r['corr']:.2f}, 지속률 {r['consistency']:.2f}"
+            )
+    return bl
+
+
+def render_quad_report(
+    path: str, pairs: pd.DataFrame, invest_table: pd.DataFrame | None = None
+) -> None:
+    dom = split_by_domain(pairs)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "# Quad Report — Economy · Corporate · Investment · Finance\n"
+            f"Generated: {datetime.now().isoformat()}\n\n"
+        )
+        for section in ["economy", "corporate", "finance", "investment"]:
+            f.write(f"## {section.capitalize()}\n")
+            if section in dom:
+                bl = bullets_for(dom[section])
+                for ln in bl:
+                    f.write(f"- {ln}\n")
+            else:
+                f.write("- (유의미한 신호 없음)\n")
+            if section == "investment" and invest_table is not None and len(invest_table):
+                f.write(
+                    "\n**Investment Tilt (β기반)**\n\n| Asset | Score/Beta | Stance |\n|---|---:|---|\n"
+                )
+                for _, r in invest_table.iterrows():
+                    f.write(f"| {r['asset']} | {r['score']:.3f} | {r['stance']} |\n")
+            f.write("\n")
+


### PR DESCRIPTION
## Summary
- add a signal discovery module that scores correlated macro series with partial correlation, Granger causality and persistence metrics
- implement Quad domain routing and Markdown report renderer with optional investment tilt table
- provide a one-click pipeline script to harvest data, run discovery, and generate the Quad report

## Testing
- python -m compileall src run_discovery_quad.py

------
https://chatgpt.com/codex/tasks/task_e_68d39f8e9fa8832d8f13f15e42b0b3d1