### PR TITLE
Add KOSIS pipeline skeleton structure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+pandas
+duckdb
+numpy

--- a/run_step1_harvest.py
+++ b/run_step1_harvest.py
@@ -1,0 +1,14 @@
+"""Step 1: Harvest statistics metadata and payloads from KOSIS."""
+
+from __future__ import annotations
+
+from src import catalog, kosis_api, store
+
+
+# TODO: orchestrate statistics list traversal (list_stats) to build candidate catalog entries.
+# TODO: fetch payloads via data_by_userstats / data_by_params and persist via store.save_raw.
+# Placeholder wiring for future implementation lives here.
+
+if __name__ == "__main__":
+    store.init()
+    print("Harvest stage placeholder. Extend with actual collection logic.")

--- a/run_step2_prepare.py
+++ b/run_step2_prepare.py
@@ -1,0 +1,13 @@
+"""Step 2: Normalise harvested payloads and engineer base features."""
+
+from __future__ import annotations
+
+from src import features, normalize, store
+
+
+# TODO: load raw payloads, parse prdSe according to KOSIS guide, and populate obs via normalize.normalize_and_store.
+# TODO: extend features.build_wide with ratio/spread/growth calculations before discovery.
+
+if __name__ == "__main__":
+    store.init()
+    print("Prepare stage placeholder. Implement normalisation and feature creation.")

--- a/run_step3_discover.py
+++ b/run_step3_discover.py
@@ -1,0 +1,13 @@
+"""Step 3: Discover cross-series relationships across the observation matrix."""
+
+from __future__ import annotations
+
+from src import discover, features, store
+
+
+# TODO: pull the obs table into a dataframe, expand quick_discover with partial correlations,
+#       Granger causality with FDR control, mutual information, and persistence/lead-lag metrics.
+
+if __name__ == "__main__":
+    store.init()
+    print("Discover stage placeholder. Expand quick_discover scoring before use.")

--- a/run_step4_causal.py
+++ b/run_step4_causal.py
@@ -1,0 +1,13 @@
+"""Step 4: Model causal structure and forecasting pathways."""
+
+from __future__ import annotations
+
+from src import causal_forecast, store
+
+
+# TODO: implement ADF/KPSS stationarity tests, differencing/log transforms, and
+#       connect fit_var_stub / irf_stub to production-ready models.
+
+if __name__ == "__main__":
+    store.init()
+    print("Causal stage placeholder. Integrate VAR/SVAR/DFM/LP pipelines here.")

--- a/run_step5_scenario.py
+++ b/run_step5_scenario.py
@@ -1,0 +1,12 @@
+"""Step 5: Apply user-defined scenarios to causal responses."""
+
+from __future__ import annotations
+
+from src import scenario, store
+
+
+# TODO: flesh out the scenario DSL (step/pulse/gradual/path) and integrate with impulse responses.
+
+if __name__ == "__main__":
+    store.init()
+    print("Scenario stage placeholder. Extend apply_scenario with DSL semantics.")

--- a/run_step6_report.py
+++ b/run_step6_report.py
@@ -1,0 +1,23 @@
+"""Step 6: Generate the final multi-section report."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from src import report, store
+
+
+# TODO: source discovery outputs and call report.render_quad8 with enriched context.
+
+if __name__ == "__main__":
+    store.init()
+    output_path = Path("report.md")
+    dummy = pd.DataFrame(
+        [
+            {"a": "gdp.real", "b": "cpi.headline", "corr": 0.42, "tier": "medium", "score": 0.42},
+        ]
+    )
+    report.render_quad8(str(output_path), dummy)
+    print(f"Report stage placeholder. Wrote {output_path} with sample content.")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,15 @@
+"""Expose top-level modules for the staged pipeline scripts."""
+
+from . import catalog, causal_forecast, discover, features, kosis_api, normalize, report, scenario, store
+
+__all__ = [
+    "catalog",
+    "causal_forecast",
+    "discover",
+    "features",
+    "kosis_api",
+    "normalize",
+    "report",
+    "scenario",
+    "store",
+]

--- a/src/catalog.py
+++ b/src/catalog.py
@@ -1,0 +1,31 @@
+"""Catalog helpers for collecting candidate KOSIS tables."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+from .kosis_api import list_stats
+
+
+def harvest_children(vw_cd: str, parent_list_id: str) -> List[dict[str, Any]]:
+    """Return child statistics list entries for the given parent identifier."""
+
+    payload = list_stats(vw_cd=vw_cd, parent_list_id=parent_list_id)
+    return [entry for entry in payload if isinstance(entry, dict)]
+
+
+def walk_catalog(vw_cd: str, parent_list_id: str, depth: int = 1) -> Iterable[dict[str, Any]]:
+    """Naïve recursive walk over the statistics list tree.
+
+    This is intentionally lightweight: production code can expand it to
+    respect the KOSIS guide paging rules or enrich metadata.
+    """
+
+    queue = [(parent_list_id, 0)]
+    while queue:
+        node_id, level = queue.pop(0)
+        children = harvest_children(vw_cd=vw_cd, parent_list_id=node_id)
+        for child in children:
+            yield child
+            if level + 1 < depth and child.get("listId"):
+                queue.append((child["listId"], level + 1))

--- a/src/causal_forecast.py
+++ b/src/causal_forecast.py
@@ -1,0 +1,21 @@
+"""Stubs for causal modelling and forecasting utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pandas as pd
+
+
+def fit_var_stub(df: pd.DataFrame) -> Optional[Any]:
+    """Placeholder for a future VAR/SVAR/DFM fitting routine."""
+
+    _ = df
+    return None
+
+
+def irf_stub(model: Any, periods: int = 8) -> Optional[Any]:
+    """Placeholder for impulse response generation."""
+
+    _ = model, periods
+    return None

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,18 @@
+"""Project configuration for the KOSIS analytics pipeline skeleton."""
+
+from __future__ import annotations
+
+import os
+
+KOSIS_API_KEY = os.getenv("KOSIS_API_KEY", "")
+TIMEOUT = 30
+MAX_RETRIES = 4
+RATE_SLEEP = 0.35  # seconds between API calls
+
+# Endpoint definitions aligned with the KOSIS OpenAPI guide.
+URL_LIST = "https://kosis.kr/openapi/statisticsList.do"
+URL_DATA = "https://kosis.kr/openapi/statisticsData.do"
+URL_PARAM = "https://kosis.kr/openapi/Param/statisticsParameterData.do"
+
+DB_PATH = os.getenv("KOSIS_DB", "kosis.duckdb")
+RAW_DIR = "data/raw"

--- a/src/discover.py
+++ b/src/discover.py
@@ -1,0 +1,32 @@
+"""Discovery stage helpers for brute-force signal ranking."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def quick_discover(wide: pd.DataFrame) -> pd.DataFrame:
+    """Compute a simple correlation-based ranking across series pairs."""
+
+    dense = wide.dropna(axis=1, how="any")
+    corr_matrix = dense.corr()
+    pairs = []
+    columns = list(corr_matrix.columns)
+    for i, lhs in enumerate(columns):
+        for j in range(i + 1, len(columns)):
+            rhs = columns[j]
+            corr_value = float(corr_matrix.iloc[i, j])
+            pairs.append({
+                "a": lhs,
+                "b": rhs,
+                "corr": corr_value,
+                "score": abs(corr_value),
+            })
+    result = pd.DataFrame(pairs).sort_values("score", ascending=False)
+    result["tier"] = np.where(
+        result["score"] >= 0.45,
+        "strong",
+        np.where(result["score"] >= 0.3, "medium", "weak"),
+    )
+    return result

--- a/src/features.py
+++ b/src/features.py
@@ -1,0 +1,20 @@
+"""Feature engineering helpers for the discovery stage."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def build_wide(df_obs: pd.DataFrame, limit: int = 600) -> pd.DataFrame:
+    """Return a wide pivoted dataframe from normalised observations."""
+
+    df = df_obs.copy()
+    df["logical_name"] = df["series_key"].str.split("|").str[0]
+    counts = df.groupby("logical_name")["period"].nunique().sort_values(ascending=False)
+    keep = counts.head(limit).index
+    wide = (
+        df[df["logical_name"].isin(keep)]
+        .pivot_table(index="period", columns="logical_name", values="value")
+        .sort_index()
+    )
+    return wide.interpolate(limit_direction="both")

--- a/src/kosis_api.py
+++ b/src/kosis_api.py
@@ -1,0 +1,92 @@
+"""Thin API client helpers for the KOSIS endpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .config import KOSIS_API_KEY, URL_DATA, URL_LIST, URL_PARAM
+from .utils import get_json
+
+
+def list_stats(vw_cd: str, parent_list_id: str, jsonVD: str = "Y") -> Any:
+    """Retrieve a statistics list for the provided view and parent list."""
+
+    params = {
+        "method": "getList",
+        "apiKey": KOSIS_API_KEY,
+        "format": "json",
+        "vwCd": vw_cd,
+        "parentListId": parent_list_id,
+        "jsonVD": jsonVD,
+    }
+    return get_json(URL_LIST, params)
+
+
+def data_by_userstats(
+    user_stats_id: str,
+    prd_se: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    newEstPrdCnt: Optional[int] = None,
+    prdInterval: Optional[int] = None,
+    outputFields: Optional[str] = None,
+) -> Any:
+    """Retrieve statistics data for the userStatsId style endpoint."""
+
+    params: Dict[str, Any] = {
+        "method": "getList",
+        "apiKey": KOSIS_API_KEY,
+        "format": "json",
+        "userStatsId": user_stats_id,
+        "prdSe": prd_se,
+    }
+    if start:
+        params["startPrdDe"] = start
+    if end:
+        params["endPrdDe"] = end
+    if newEstPrdCnt:
+        params["newEstPrdCnt"] = newEstPrdCnt
+    if prdInterval:
+        params["prdInterval"] = prdInterval
+    if outputFields:
+        params["outputFields"] = outputFields
+    return get_json(URL_DATA, params)
+
+
+def data_by_params(
+    org_id: str,
+    tbl_id: str,
+    prd_se: str,
+    obj: Optional[Dict[str, str]],
+    itm_id: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    newEstPrdCnt: Optional[int] = None,
+    prdInterval: Optional[int] = None,
+    outputFields: str = "PRD_DE,DT,UNIT_NM",
+) -> Any:
+    """Retrieve statistics data for the parameterised table endpoint."""
+
+    params: Dict[str, Any] = {
+        "method": "getList",
+        "apiKey": KOSIS_API_KEY,
+        "format": "json",
+        "orgId": org_id,
+        "tblId": tbl_id,
+        "prdSe": prd_se,
+        "itmId": itm_id,
+    }
+    for key, value in (obj or {}).items():
+        if key.lower().startswith("objl") and value:
+            params[key] = value
+    if start:
+        params["startPrdDe"] = start
+    if end:
+        params["endPrdDe"] = end
+    if newEstPrdCnt:
+        params["newEstPrdCnt"] = newEstPrdCnt
+    if prdInterval:
+        params["prdInterval"] = prdInterval
+    if outputFields:
+        params["outputFields"] = outputFields
+    return get_json(URL_PARAM, params)

--- a/src/normalize.py
+++ b/src/normalize.py
@@ -1,0 +1,62 @@
+"""Normalisation helpers for aligning KOSIS payloads to the obs table."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Iterable
+
+import pandas as pd
+
+from .store import upsert_obs
+
+
+def period_to_anchor(prd_de: str, prd_se: str) -> tuple[str, str]:
+    """Convert KOSIS period descriptors into ISO date anchors and frequency codes."""
+
+    digits = re.sub(r"[^0-9]", "", str(prd_de))
+    if prd_se == "M":
+        period = pd.Period(f"{digits[:4]}-{digits[4:6]}", freq="M").to_timestamp("M").strftime("%Y-%m-%d")
+        return period, "M"
+    if prd_se == "Q":
+        year, quarter = digits[:4], digits[-1]
+        period = pd.Period(f"{year}Q{quarter}", freq="Q").to_timestamp("Q").strftime("%Y-%m-%d")
+        return period, "Q"
+    if prd_se == "Y":
+        period = pd.Period(digits[:4], freq="A").to_timestamp("A").strftime("%Y-%m-%d")
+        return period, "Y"
+    return digits, prd_se
+
+
+def flatten_payload(logical_name: str, rows: Iterable[dict], prd_se: str) -> pd.DataFrame:
+    """Flatten the raw payload rows into the obs schema."""
+
+    records = []
+    for row in rows:
+        period_value = row.get("PRD_DE") or row.get("prdDe")
+        value = row.get("DT") or row.get("DATA_VALUE") or row.get("value")
+        unit = row.get("UNIT_NM") or row.get("UNIT_NM_ENG") or ""
+        if period_value is None or value in (None, ""):
+            continue
+        period, freq = period_to_anchor(str(period_value), prd_se)
+        dims = {key: val for key, val in row.items() if key not in ("PRD_DE", "DT")}
+        series_key = logical_name + "|" + json.dumps(dims, ensure_ascii=False, sort_keys=True)
+        records.append(
+            {
+                "series_key": series_key,
+                "period": period,
+                "freq": freq,
+                "value": float(value),
+                "unit": unit,
+                "dims": json.dumps(dims, ensure_ascii=False),
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def normalize_and_store(logical_name: str, payload_rows: Iterable[dict], prd_se: str) -> None:
+    """Normalise the supplied payload and persist the resulting observations."""
+
+    frame = flatten_payload(logical_name, payload_rows, prd_se)
+    if not frame.empty:
+        upsert_obs(frame)

--- a/src/report.py
+++ b/src/report.py
@@ -1,0 +1,67 @@
+"""Reporting helpers for the staged pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Iterable, List
+
+import pandas as pd
+
+SECTIONS = [
+    "Economy",
+    "Corporate",
+    "Finance",
+    "Investment",
+    "Real Estate",
+    "Debt",
+    "Growth",
+    "Assets",
+]
+
+
+def route_section(name: str) -> str:
+    """Route a logical series name to one of the eight canonical sections."""
+
+    lowered = name.lower()
+    if lowered.startswith("firm.") or any(keyword in lowered for keyword in ("employment", "capex", "sales")):
+        return "Corporate"
+    if lowered.startswith("asset.") or any(keyword in lowered for keyword in ("etf", "reits", "bond", "gold")):
+        return "Investment"
+    if any(keyword in lowered for keyword in ["house", "real_estate", "housing", "rent", "construction"]):
+        return "Real Estate"
+    if any(keyword in lowered for keyword in ["debt", "dsr", "dti", "leverage", "npl"]):
+        return "Debt"
+    if any(keyword in lowered for keyword in ["potential", "tfp", "productivity", "growth", "income", "consumption", "saving"]):
+        return "Growth"
+    if any(keyword in lowered for keyword in ["policy_rate", "m2", "credit", "spread", "loan_to_deposit", "bank_loan"]):
+        return "Finance"
+    if any(keyword in lowered for keyword in ["gdp", "cpi", "ppi", "trade", "fx", "population"]):
+        return "Economy"
+    return "Assets"
+
+
+def render_quad8(path: str, pairs_df: pd.DataFrame) -> None:
+    """Render the eight-section plus cross-domain markdown report."""
+
+    domain_map: Dict[str, List[pd.Series]] = {}
+    for _, row in pairs_df.iterrows():
+        section_a = route_section(row["a"])
+        section_b = route_section(row["b"])
+        section = section_a if section_a == section_b else "Cross-Domain"
+        domain_map.setdefault(section, []).append(row)
+
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(f"# KOSIS Cross-Domain Report\nGenerated: {datetime.now().isoformat()}\n\n")
+        handle.write("## Executive Summary\n")
+        for row in pairs_df.head(10).itertuples():
+            handle.write(f"- {row.a} ↔ {row.b}: corr {row.corr:.2f}\n")
+        for section in SECTIONS + ["Cross-Domain"]:
+            handle.write(f"\n## {section}\n")
+            rows = domain_map.get(section, [])[:12]
+            if not rows:
+                handle.write("- (신호 없음)\n")
+                continue
+            for row in rows:
+                handle.write(
+                    f"- {row['a']} ↔ {row['b']} (corr {row['corr']:.2f}, tier {row['tier']})\n"
+                )

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -1,0 +1,12 @@
+"""Scenario DSL stubs for future expansion."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional
+
+
+def apply_scenario(irf_obj: Any, variables: Iterable[str], scen: Optional[Dict[str, Any]]) -> None:
+    """Placeholder implementation for scenario application logic."""
+
+    _ = irf_obj, variables, scen
+    return None

--- a/src/store.py
+++ b/src/store.py
@@ -1,0 +1,79 @@
+"""Persistence helpers for the KOSIS pipeline."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+import duckdb
+import pandas as pd
+
+from .config import DB_PATH
+
+
+def con() -> duckdb.DuckDBPyConnection:
+    """Return a new DuckDB connection bound to the configured database."""
+
+    return duckdb.connect(DB_PATH)
+
+
+def init() -> duckdb.DuckDBPyConnection:
+    """Initialise storage tables for raw payloads and normalised observations."""
+
+    connection = con()
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS raw_kosis (
+          src TEXT,
+          key TEXT,
+          fetched_at TIMESTAMP,
+          payload JSON
+        );
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS obs (
+          series_key TEXT,
+          period TEXT,
+          freq TEXT,
+          value DOUBLE,
+          unit TEXT,
+          dims JSON
+        );
+        """
+    )
+    return connection
+
+
+def save_raw(src: str, key: str, df_json: Iterable[dict]) -> None:
+    """Persist the original JSON payload for traceability."""
+
+    connection = con()
+    connection.execute(
+        "INSERT INTO raw_kosis VALUES (?, ?, now(), ?)",
+        [src, key, json.dumps(list(df_json), ensure_ascii=False)],
+    )
+    connection.close()
+
+
+def upsert_obs(df: pd.DataFrame) -> None:
+    """Upsert a normalised observation dataframe into DuckDB."""
+
+    connection = con()
+    connection.register("df", df)
+    connection.execute(  # DuckDB v0.9+ MERGE support
+        """
+        CREATE TEMP TABLE t AS SELECT * FROM df;
+        MERGE INTO obs o USING t s
+        ON o.series_key = s.series_key AND o.period = s.period
+        WHEN MATCHED THEN UPDATE SET
+            value = s.value,
+            unit = s.unit,
+            dims = s.dims,
+            freq = s.freq
+        WHEN NOT MATCHED THEN INSERT (series_key, period, freq, value, unit, dims)
+        VALUES (s.series_key, s.period, s.freq, s.value, s.unit, s.dims);
+        """
+    )
+    connection.close()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,34 @@
+"""Utility helpers shared across the KOSIS pipeline."""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any
+
+import requests
+
+from .config import MAX_RETRIES, RATE_SLEEP, TIMEOUT
+
+
+def get_json(url: str, params: dict[str, Any]) -> Any:
+    """Perform a GET request with retry/backoff logic and KOSIS specific guards."""
+
+    backoff = 0.6
+    for attempt in range(MAX_RETRIES):
+        try:
+            time.sleep(RATE_SLEEP)
+            response = requests.get(url, params=params, timeout=TIMEOUT)
+            if response.status_code in (429, 500, 502, 503, 504):
+                raise requests.HTTPError(str(response.status_code))
+            response.raise_for_status()
+            payload = response.json()
+            if isinstance(payload, dict) and (payload.get("errMsg") or payload.get("errorMsg")):
+                raise RuntimeError(str(payload))
+            if isinstance(payload, dict) and isinstance(payload.get("list"), list):
+                return payload["list"]
+            return payload
+        except Exception:  # pragma: no cover - thin wrapper over network I/O
+            if attempt == MAX_RETRIES - 1:
+                raise
+            time.sleep(backoff * (1.6 ** attempt) + random.uniform(0, 0.3))


### PR DESCRIPTION
## Summary
- scaffold the KOSIS analytics project layout with staged pipeline scripts
- implement minimal API, storage, normalisation, discovery, and reporting helpers following the KOSIS guide
- add placeholder causal, scenario, and reporting integrations ready for future expansion

## Testing
- python -m compileall src run_step1_harvest.py run_step2_prepare.py run_step3_discover.py run_step4_causal.py run_step5_scenario.py run_step6_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b6133d78832db54d361e78df1742