### PR TITLE
Implement KOSIS catalog and data fetch utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
-pandas
-duckdb
-numpy
+requests==2.32.3
+pandas==2.2.2
+PyYAML==6.0.2
+tqdm==4.66.4

--- a/run_build_catalog.py
+++ b/run_build_catalog.py
@@ -1,0 +1,34 @@
+"""CLI utility to build catalog candidates from the KOSIS list API."""
+
+from __future__ import annotations
+
+import argparse
+
+from src.catalog_builder import build_catalog
+from src.io_helpers import save_csv
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--vwcd",
+        default="MT_ZTITLE",
+        help="목록 보기 코드(예: MT_ZTITLE=주제별, MT_GTITLE=기관별)",
+    )
+    parser.add_argument(
+        "--roots",
+        nargs="+",
+        required=True,
+        help="parentListId 루트들(여러 개 가능)",
+    )
+    parser.add_argument("--out", default="series_catalog.csv")
+    parser.add_argument("--max-depth", type=int, default=6)
+    args = parser.parse_args()
+
+    df = build_catalog(args.vwcd, args.roots, max_depth=args.max_depth)
+    save_csv(df, args.out)
+    print(f"[catalog] 후보 {len(df)}건 저장 → {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_fetch_data.py
+++ b/run_fetch_data.py
@@ -1,0 +1,49 @@
+"""CLI to fetch KOSIS data payloads based on a prepared catalog file."""
+
+from __future__ import annotations
+
+import argparse
+
+import pandas as pd
+from tqdm import tqdm
+
+from src.fetcher import fetch_row
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--catalog",
+        default="series_catalog.csv",
+        help="수집용 CSV (필드: mode/prdSe/startPrdDe/endPrdDe/…)",
+    )
+    parser.add_argument("--out", default="out_data.parquet")
+    args = parser.parse_args()
+
+    catalog = pd.read_csv(args.catalog, dtype=str).fillna("")
+    out_rows = []
+    for _, row in tqdm(catalog.iterrows(), total=len(catalog)):
+        try:
+            df = fetch_row(row.to_dict())
+            df.insert(0, "logical_name", row.get("logical_name", ""))
+            df.insert(1, "orgId", row.get("orgId", ""))
+            df.insert(2, "tblId", row.get("tblId", ""))
+            out_rows.append(df)
+        except Exception as exc:  # pragma: no cover - network usage
+            print(
+                "[ERR]",
+                row.get("logical_name", ""),
+                row.get("orgId", ""),
+                row.get("tblId", ""),
+                str(exc),
+            )
+    if out_rows:
+        all_df = pd.concat(out_rows, ignore_index=True)
+        all_df.to_parquet(args.out, index=False)
+        print(f"[fetch] 총 {len(all_df):,} 행 저장 → {args.out}")
+    else:
+        print("[fetch] 저장할 데이터가 없습니다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/series_catalog.csv
+++ b/series_catalog.csv
@@ -1,0 +1,4 @@
+logical_name,mode,prdSe,startPrdDe,endPrdDe,userStatsId,orgId,tblId,itmId,objL1,objL2,objL3,objL4,objL5,objL6,objL7,objL8,newEstPrdCnt,prdInterval,outputFields
+macro.cpi,param,M,199001,,,101,DT_CPI,1,,A01,,,,,,,,"PRD_DE,DT,UNIT_NM"
+macro.policy_rate,param,M,200001,,,201,DT_RATE,100,,,,,,,,,,,"PRD_DE,DT,UNIT_NM"
+asset.kospi,user,M,199501,,user_abcdef,,,,,,,,,,,,,"PRD_DE,DT,UNIT_NM"

--- a/src/catalog_builder.py
+++ b/src/catalog_builder.py
@@ -1,0 +1,61 @@
+"""Build candidate table catalogues by traversing the KOSIS list API."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from .kosis_api import list_stats
+
+
+def _extract(row: Dict[str, Any], key: str) -> Any:
+    """Return a value using a handful of common key variants."""
+
+    return row.get(key) or row.get(key.upper()) or row.get(key.lower())
+
+
+def build_catalog(vw_cd: str, roots: List[str], max_depth: int = 6) -> pd.DataFrame:
+    """Traverse the statistics list tree and collect nodes that expose tables."""
+
+    rows: List[Dict[str, Any]] = []
+    for root in roots:
+        queue: deque[tuple[str, int]] = deque([(root, 0)])
+        while queue:
+            parent, depth = queue.popleft()
+            if depth > max_depth:
+                continue
+            items = list_stats(vw_cd, parent)
+            for item in items:
+                item["depth"] = depth
+                rows.append(item)
+                next_id = (
+                    item.get("listId")
+                    or item.get("LIST_ID")
+                    or item.get("list_id")
+                )
+                if next_id:
+                    queue.append((str(next_id), depth + 1))
+
+    df = pd.DataFrame(rows)
+
+    candidates: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        record = row.to_dict()
+        org = _extract(record, "orgId")
+        tbl = _extract(record, "tblId")
+        if org and tbl:
+            candidates.append(
+                {
+                    "listId": _extract(record, "listId") or _extract(record, "LIST_ID"),
+                    "listNm": _extract(record, "listNm") or _extract(record, "LIST_NM"),
+                    "orgId": org,
+                    "tblId": tbl,
+                    "upListId": _extract(record, "upListId")
+                    or _extract(record, "UP_LIST_ID"),
+                    "depth": record.get("depth"),
+                }
+            )
+
+    return pd.DataFrame(candidates).drop_duplicates()

--- a/src/config.py
+++ b/src/config.py
@@ -1,18 +1,20 @@
-"""Project configuration for the KOSIS analytics pipeline skeleton."""
+"""Lightweight configuration module for the standalone KOSIS helpers."""
 
 from __future__ import annotations
 
 import os
 
+# NOTE: ``KOSIS_API_KEY`` *must* be configured by the caller.  The scripts keep the
+# empty-string default so the configuration module can be imported safely during
+# testing, but network calls will fail until the environment variable is set.
 KOSIS_API_KEY = os.getenv("KOSIS_API_KEY", "")
+
 TIMEOUT = 30
 MAX_RETRIES = 4
 RATE_SLEEP = 0.35  # seconds between API calls
 
-# Endpoint definitions aligned with the KOSIS OpenAPI guide.
+# Endpoint definitions aligned with the official KOSIS OpenAPI guide.
 URL_LIST = "https://kosis.kr/openapi/statisticsList.do"
 URL_DATA = "https://kosis.kr/openapi/statisticsData.do"
 URL_PARAM = "https://kosis.kr/openapi/Param/statisticsParameterData.do"
-
-DB_PATH = os.getenv("KOSIS_DB", "kosis.duckdb")
-RAW_DIR = "data/raw"
+URL_META = "https://kosis.kr/openapi/statisticsData.do"

--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -1,0 +1,60 @@
+"""Utilities for fetching data payloads using catalog rows."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from .kosis_api import data_by_params, data_by_userstats, get_meta_table
+from .validator import normalize_range
+
+
+def fetch_row(row: Dict[str, Any]) -> pd.DataFrame:
+    """Fetch a dataframe for a single catalog row."""
+
+    prd_se = str(row.get("prdSe", "")).strip()
+    start, end = normalize_range(
+        prd_se, row.get("startPrdDe") or None, row.get("endPrdDe") or None
+    )
+
+    mode = row.get("mode")
+    if not mode:
+        mode = "user" if row.get("userStatsId") else "param"
+
+    if mode == "user":
+        data = data_by_userstats(
+            user_stats_id=str(row["userStatsId"]),
+            prd_se=prd_se,
+            start=start,
+            end=end,
+            newEstPrdCnt=row.get("newEstPrdCnt") or None,
+            prdInterval=row.get("prdInterval") or None,
+            outputFields=row.get("outputFields") or "PRD_DE,DT,UNIT_NM",
+        )
+    else:
+        obj = {
+            key: str(row[key])
+            for key in [f"objL{i}" for i in range(1, 9)]
+            if key in row and str(row[key]).strip() != ""
+        }
+        data = data_by_params(
+            org_id=str(row["orgId"]),
+            tbl_id=str(row["tblId"]),
+            prd_se=prd_se,
+            obj=obj,
+            itm_id=str(row["itmId"]),
+            start=start,
+            end=end,
+            newEstPrdCnt=row.get("newEstPrdCnt") or None,
+            prdInterval=row.get("prdInterval") or None,
+            outputFields=row.get("outputFields") or "PRD_DE,DT,UNIT_NM",
+        )
+
+    return pd.DataFrame(data)
+
+
+def enrich_with_meta_if_needed(org_id: str, tbl_id: str) -> Dict[str, Any]:
+    """Fetch table metadata (classification/item definitions) when required."""
+
+    return get_meta_table(org_id, tbl_id)

--- a/src/io_helpers.py
+++ b/src/io_helpers.py
@@ -1,0 +1,21 @@
+"""Small IO helpers for catalog/data persistence."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pandas as pd
+import yaml
+
+
+def save_csv(df: pd.DataFrame, path: str) -> None:
+    """Persist a dataframe to CSV without the index."""
+
+    df.to_csv(path, index=False)
+
+
+def save_yaml(series: List[Dict[str, Any]], path: str) -> None:
+    """Persist the provided series descriptors to YAML."""
+
+    with open(path, "w", encoding="utf-8") as file:
+        yaml.safe_dump({"series": series}, file, allow_unicode=True, sort_keys=False)

--- a/src/kosis_api.py
+++ b/src/kosis_api.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
-from .config import KOSIS_API_KEY, URL_DATA, URL_LIST, URL_PARAM
+from .config import KOSIS_API_KEY, URL_DATA, URL_LIST, URL_META, URL_PARAM
 from .utils import get_json
 
 
-def list_stats(vw_cd: str, parent_list_id: str, jsonVD: str = "Y") -> Any:
+def list_stats(vw_cd: str, parent_list_id: str, jsonVD: str = "Y") -> List[Dict[str, Any]]:
     """Retrieve a statistics list for the provided view and parent list."""
 
     params = {
@@ -64,7 +64,7 @@ def data_by_params(
     newEstPrdCnt: Optional[int] = None,
     prdInterval: Optional[int] = None,
     outputFields: str = "PRD_DE,DT,UNIT_NM",
-) -> Any:
+) -> List[Dict[str, Any]]:
     """Retrieve statistics data for the parameterised table endpoint."""
 
     params: Dict[str, Any] = {
@@ -89,4 +89,22 @@ def data_by_params(
         params["prdInterval"] = prdInterval
     if outputFields:
         params["outputFields"] = outputFields
+    if not any(key for key in params if key.lower().startswith("objl")):
+        raise ValueError("Param API 호출 시 objL1~objL8 중 최소 1개가 필요합니다.")
+    if not itm_id:
+        raise ValueError("Param API 호출 시 itmId는 필수입니다.")
     return get_json(URL_PARAM, params)
+
+
+def get_meta_table(org_id: str, tbl_id: str) -> Dict[str, Any]:
+    """Fetch table metadata for the supplied organisation/table identifiers."""
+
+    params = {
+        "method": "getMeta",
+        "apiKey": KOSIS_API_KEY,
+        "format": "json",
+        "type": "TBL",
+        "orgId": org_id,
+        "tblId": tbl_id,
+    }
+    return get_json(URL_META, params)

--- a/src/validator.py
+++ b/src/validator.py
@@ -1,0 +1,54 @@
+"""Validation helpers for KOSIS period parameters."""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+# prdSe 허용: Y(연), M(월), Q(분기), S(반기), D(일), F(수시), IR(부정기) 등
+VALID_PRDSE = {"Y", "M", "Q", "S", "D", "F", "IR"}
+
+
+def validate_prdse(prd_se: str) -> None:
+    """Ensure the provided ``prdSe`` value matches the official whitelist."""
+
+    if prd_se not in VALID_PRDSE:
+        raise ValueError(
+            f"prdSe가 올바르지 않습니다: {prd_se} (허용: {sorted(VALID_PRDSE)})"
+        )
+
+
+def normalize_period_str(prd_se: str, yyyx: str) -> str:
+    """Normalize the period string according to the KOSIS specification."""
+
+    s = re.sub(r"[^0-9Qq]", "", str(yyyx))
+    if prd_se == "Q":
+        match = re.match(r"^(\d{4})[Qq]([1-4])$", s)
+        if not match:
+            raise ValueError(
+                f"분기 prdSe=Q는 YYYYQ[1-4] 형식이어야 합니다: {yyyx}"
+            )
+        return f"{match.group(1)}Q{match.group(2)}"
+    if prd_se == "M":
+        match = re.match(r"^(\d{4})(0[1-9]|1[0-2])$", s)
+        if not match:
+            raise ValueError(f"월 prdSe=M은 YYYYMM 형식이어야 합니다: {yyyx}")
+        return f"{match.group(1)}{match.group(2)}"
+    if prd_se == "Y":
+        match = re.match(r"^(\d{4})$", s)
+        if not match:
+            raise ValueError(f"연 prdSe=Y는 YYYY 형식이어야 합니다: {yyyx}")
+        return match.group(1)
+    # S/D/F/IR 등은 데이터셋별 케이스가 다양 → 우선 원본 유지(필요 시 확장)
+    return yyyx
+
+
+def normalize_range(
+    prd_se: str, start: str | None = None, end: str | None = None
+) -> Tuple[str | None, str | None]:
+    """Normalize start/end period strings using the validation helpers."""
+
+    validate_prdse(prd_se)
+    ns = normalize_period_str(prd_se, start) if start else None
+    ne = normalize_period_str(prd_se, end) if end else None
+    return ns, ne


### PR DESCRIPTION
## Summary
- align the configuration and API helpers with the KOSIS OpenAPI endpoints, including metadata retrieval
- add validation, catalog building, fetching, and IO helpers to support the list→catalog→data workflow
- provide CLI scripts plus an example catalog CSV for building catalogs and harvesting datasets

## Testing
- python -m compileall src run_build_catalog.py run_fetch_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b7a32304832d9ea0495bb0fce071