### PR TITLE
Implement normalization, feature engineering, and discovery pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
-requests
-pandas
-duckdb
-numpy
+requests==2.32.3
+pandas==2.2.2
+PyYAML==6.0.2
+tqdm==4.66.4
+numpy==1.26.4
+duckdb==0.9.2
+scikit-learn==1.4.2
+statsmodels==0.14.2
+pyarrow==15.0.2

--- a/run_build_catalog.py
+++ b/run_build_catalog.py
@@ -1,0 +1,34 @@
+"""CLI utility to build catalog candidates from the KOSIS list API."""
+
+from __future__ import annotations
+
+import argparse
+
+from src.catalog_builder import build_catalog
+from src.io_helpers import save_csv
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--vwcd",
+        default="MT_ZTITLE",
+        help="목록 보기 코드(예: MT_ZTITLE=주제별, MT_GTITLE=기관별)",
+    )
+    parser.add_argument(
+        "--roots",
+        nargs="+",
+        required=True,
+        help="parentListId 루트들(여러 개 가능)",
+    )
+    parser.add_argument("--out", default="series_catalog.csv")
+    parser.add_argument("--max-depth", type=int, default=6)
+    args = parser.parse_args()
+
+    df = build_catalog(args.vwcd, args.roots, max_depth=args.max_depth)
+    save_csv(df, args.out)
+    print(f"[catalog] 후보 {len(df)}건 저장 → {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_fetch_data.py
+++ b/run_fetch_data.py
@@ -1,0 +1,49 @@
+"""CLI to fetch KOSIS data payloads based on a prepared catalog file."""
+
+from __future__ import annotations
+
+import argparse
+
+import pandas as pd
+from tqdm import tqdm
+
+from src.fetcher import fetch_row
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--catalog",
+        default="series_catalog.csv",
+        help="수집용 CSV (필드: mode/prdSe/startPrdDe/endPrdDe/…)",
+    )
+    parser.add_argument("--out", default="out_data.parquet")
+    args = parser.parse_args()
+
+    catalog = pd.read_csv(args.catalog, dtype=str).fillna("")
+    out_rows = []
+    for _, row in tqdm(catalog.iterrows(), total=len(catalog)):
+        try:
+            df = fetch_row(row.to_dict())
+            df.insert(0, "logical_name", row.get("logical_name", ""))
+            df.insert(1, "orgId", row.get("orgId", ""))
+            df.insert(2, "tblId", row.get("tblId", ""))
+            out_rows.append(df)
+        except Exception as exc:  # pragma: no cover - network usage
+            print(
+                "[ERR]",
+                row.get("logical_name", ""),
+                row.get("orgId", ""),
+                row.get("tblId", ""),
+                str(exc),
+            )
+    if out_rows:
+        all_df = pd.concat(out_rows, ignore_index=True)
+        all_df.to_parquet(args.out, index=False)
+        print(f"[fetch] 총 {len(all_df):,} 행 저장 → {args.out}")
+    else:
+        print("[fetch] 저장할 데이터가 없습니다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_step2_prepare.py
+++ b/run_step2_prepare.py
@@ -1,13 +1,69 @@
-"""Step 2: Normalise harvested payloads and engineer base features."""
+"""Step 2: Normalise harvested payloads and engineer wide feature matrices."""
 
 from __future__ import annotations
 
-from src import features, normalize, store
+import argparse
+import glob
+import json
+from typing import List
+
+import pandas as pd
+from tqdm import tqdm
+
+from src.normalize import normalize_payload, store_obs
+from src.features import build_wide
+from src import store
 
 
-# TODO: load raw payloads, parse prdSe according to KOSIS guide, and populate obs via normalize.normalize_and_store.
-# TODO: extend features.build_wide with ratio/spread/growth calculations before discovery.
+def _load_json_glob(pattern: str) -> pd.DataFrame:
+    frames: List[pd.DataFrame] = []
+    for path in glob.glob(pattern):
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        frames.append(pd.DataFrame(payload))
+    return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+
+def _load_raw(path: str) -> pd.DataFrame:
+    if path.endswith(".parquet"):
+        return pd.read_parquet(path)
+    if path.endswith(".csv"):
+        return pd.read_csv(path)
+    return _load_json_glob(path)
+
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--raw", default="out_data.parquet", help="Harvest output from step 1 (parquet preferred).")
+    parser.add_argument("--prdSe", default=None, help="Fallback prdSe to apply when the raw dataset omits it.")
+    parser.add_argument("--logical-name", default="kosis.series", help="Fallback logical_name for unnamed payloads.")
+    parser.add_argument("--wide-out", default="out_wide.parquet", help="Destination path for the engineered wide frame.")
+    parser.add_argument("--limit", type=int, default=1200, help="Maximum logical series to retain in the wide matrix.")
+    args = parser.parse_args()
+
     store.init()
-    print("Prepare stage placeholder. Implement normalisation and feature creation.")
+    raw = _load_raw(args.raw)
+    if raw.empty:
+        print("[prepare] No raw records found – skipping normalisation.")
+    else:
+        if "prdSe" not in raw.columns and args.prdSe:
+            raw["prdSe"] = args.prdSe
+        if "logical_name" not in raw.columns:
+            raw["logical_name"] = args.logical_name
+
+        groups = raw.groupby(["logical_name", "prdSe"], dropna=False)
+        for (logical_name, prd_se), group in tqdm(groups, total=groups.ngroups):
+            rows = group.to_dict(orient="records")
+            try:
+                df_norm = normalize_payload(str(logical_name), rows, str(prd_se))
+            except ValueError as exc:
+                print(f"[prepare] skip logical_name={logical_name} prdSe={prd_se}: {exc}")
+                continue
+            store_obs(df_norm)
+
+    wide = build_wide(limit=args.limit)
+    if wide.empty:
+        print("[prepare] No observations available for wide matrix construction.")
+    else:
+        wide.to_parquet(args.wide_out)
+        print(f"[prepare] wide shape={wide.shape} → {args.wide_out}")

--- a/run_step3_discover.py
+++ b/run_step3_discover.py
@@ -1,13 +1,33 @@
-"""Step 3: Discover cross-series relationships across the observation matrix."""
+"""Step 3: Exhaustive discovery of cross-series relationships."""
 
 from __future__ import annotations
 
-from src import discover, features, store
+import argparse
 
+import pandas as pd
 
-# TODO: pull the obs table into a dataframe, expand quick_discover with partial correlations,
-#       Granger causality with FDR control, mutual information, and persistence/lead-lag metrics.
+from src.discover import discover_all
+
 
 if __name__ == "__main__":
-    store.init()
-    print("Discover stage placeholder. Expand quick_discover scoring before use.")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wide", default="out_wide.parquet", help="Wide feature matrix produced by step 2.")
+    parser.add_argument("--out", default="out_signals.csv", help="Output CSV path for ranked signal pairs.")
+    parser.add_argument("--corr-strong", type=float, default=0.45, help="Threshold for strong correlation tiering.")
+    parser.add_argument("--corr-medium", type=float, default=0.30, help="Threshold for medium correlation tiering.")
+    parser.add_argument("--maxlag", type=int, default=4, help="Maximum lag for Granger causality testing.")
+    args = parser.parse_args()
+
+    wide = pd.read_parquet(args.wide)
+    pairs = discover_all(
+        wide,
+        corr_thr_strong=args.corr_strong,
+        corr_thr_medium=args.corr_medium,
+        maxlag=args.maxlag,
+    )
+    if pairs.empty:
+        print("[discover] No eligible pairs identified.")
+    else:
+        filtered = pairs[pairs["tier"].isin(["strong", "medium"])].copy()
+        filtered.to_csv(args.out, index=False)
+        print(f"[discover] pairs={len(pairs)} saved → {args.out}")

--- a/series_catalog.csv
+++ b/series_catalog.csv
@@ -1,0 +1,4 @@
+logical_name,mode,prdSe,startPrdDe,endPrdDe,userStatsId,orgId,tblId,itmId,objL1,objL2,objL3,objL4,objL5,objL6,objL7,objL8,newEstPrdCnt,prdInterval,outputFields
+macro.cpi,param,M,199001,,,101,DT_CPI,1,,A01,,,,,,,,"PRD_DE,DT,UNIT_NM"
+macro.policy_rate,param,M,200001,,,201,DT_RATE,100,,,,,,,,,,,"PRD_DE,DT,UNIT_NM"
+asset.kospi,user,M,199501,,user_abcdef,,,,,,,,,,,,,"PRD_DE,DT,UNIT_NM"

--- a/src/catalog_builder.py
+++ b/src/catalog_builder.py
@@ -1,0 +1,61 @@
+"""Build candidate table catalogues by traversing the KOSIS list API."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from .kosis_api import list_stats
+
+
+def _extract(row: Dict[str, Any], key: str) -> Any:
+    """Return a value using a handful of common key variants."""
+
+    return row.get(key) or row.get(key.upper()) or row.get(key.lower())
+
+
+def build_catalog(vw_cd: str, roots: List[str], max_depth: int = 6) -> pd.DataFrame:
+    """Traverse the statistics list tree and collect nodes that expose tables."""
+
+    rows: List[Dict[str, Any]] = []
+    for root in roots:
+        queue: deque[tuple[str, int]] = deque([(root, 0)])
+        while queue:
+            parent, depth = queue.popleft()
+            if depth > max_depth:
+                continue
+            items = list_stats(vw_cd, parent)
+            for item in items:
+                item["depth"] = depth
+                rows.append(item)
+                next_id = (
+                    item.get("listId")
+                    or item.get("LIST_ID")
+                    or item.get("list_id")
+                )
+                if next_id:
+                    queue.append((str(next_id), depth + 1))
+
+    df = pd.DataFrame(rows)
+
+    candidates: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        record = row.to_dict()
+        org = _extract(record, "orgId")
+        tbl = _extract(record, "tblId")
+        if org and tbl:
+            candidates.append(
+                {
+                    "listId": _extract(record, "listId") or _extract(record, "LIST_ID"),
+                    "listNm": _extract(record, "listNm") or _extract(record, "LIST_NM"),
+                    "orgId": org,
+                    "tblId": tbl,
+                    "upListId": _extract(record, "upListId")
+                    or _extract(record, "UP_LIST_ID"),
+                    "depth": record.get("depth"),
+                }
+            )
+
+    return pd.DataFrame(candidates).drop_duplicates()

--- a/src/config.py
+++ b/src/config.py
@@ -1,18 +1,23 @@
-"""Project configuration for the KOSIS analytics pipeline skeleton."""
+"""Lightweight configuration module for the standalone KOSIS helpers."""
 
 from __future__ import annotations
 
 import os
 
+# NOTE: ``KOSIS_API_KEY`` *must* be configured by the caller.  The scripts keep the
+# empty-string default so the configuration module can be imported safely during
+# testing, but network calls will fail until the environment variable is set.
 KOSIS_API_KEY = os.getenv("KOSIS_API_KEY", "")
+
 TIMEOUT = 30
 MAX_RETRIES = 4
 RATE_SLEEP = 0.35  # seconds between API calls
 
-# Endpoint definitions aligned with the KOSIS OpenAPI guide.
+# Endpoint definitions aligned with the official KOSIS OpenAPI guide.
 URL_LIST = "https://kosis.kr/openapi/statisticsList.do"
 URL_DATA = "https://kosis.kr/openapi/statisticsData.do"
 URL_PARAM = "https://kosis.kr/openapi/Param/statisticsParameterData.do"
+URL_META = "https://kosis.kr/openapi/statisticsData.do"
 
-DB_PATH = os.getenv("KOSIS_DB", "kosis.duckdb")
-RAW_DIR = "data/raw"
+# Local DuckDB path used for staging normalised observations across the pipeline.
+DB_PATH = os.getenv("KOSIS_DB_PATH", "kosis.duckdb")

--- a/src/discover.py
+++ b/src/discover.py
@@ -1,32 +1,118 @@
-"""Discovery stage helpers for brute-force signal ranking."""
+"""Brute-force discovery helpers for cross-series relationship screening."""
 
 from __future__ import annotations
 
+import itertools
+from typing import Tuple
+
 import numpy as np
 import pandas as pd
+from sklearn.feature_selection import mutual_info_regression
+from sklearn.preprocessing import StandardScaler
+from statsmodels.stats.multitest import multipletests
+from statsmodels.tsa.stattools import grangercausalitytests
 
 
-def quick_discover(wide: pd.DataFrame) -> pd.DataFrame:
-    """Compute a simple correlation-based ranking across series pairs."""
+def _partial_corr(df: pd.DataFrame) -> pd.DataFrame:
+    X = (df - df.mean()) / df.std(ddof=0)
+    X = X.dropna(axis=1, how="any").dropna()
+    if X.empty:
+        return pd.DataFrame()
+    cov = np.cov(X.values, rowvar=False)
+    precision = np.linalg.pinv(cov)
+    diag = np.sqrt(np.diag(precision))
+    pcorr = -precision / np.outer(diag, diag)
+    np.fill_diagonal(pcorr, 1.0)
+    return pd.DataFrame(pcorr, index=X.columns, columns=X.columns)
 
-    dense = wide.dropna(axis=1, how="any")
-    corr_matrix = dense.corr()
-    pairs = []
-    columns = list(corr_matrix.columns)
-    for i, lhs in enumerate(columns):
-        for j in range(i + 1, len(columns)):
-            rhs = columns[j]
-            corr_value = float(corr_matrix.iloc[i, j])
-            pairs.append({
-                "a": lhs,
-                "b": rhs,
-                "corr": corr_value,
-                "score": abs(corr_value),
-            })
-    result = pd.DataFrame(pairs).sort_values("score", ascending=False)
-    result["tier"] = np.where(
-        result["score"] >= 0.45,
-        "strong",
-        np.where(result["score"] >= 0.3, "medium", "weak"),
-    )
-    return result
+
+def _mi(a: np.ndarray, b: np.ndarray) -> float:
+    mask = np.isfinite(a) & np.isfinite(b)
+    if mask.sum() < 30:
+        return 0.0
+    scaler = StandardScaler()
+    x_scaled = scaler.fit_transform(a[mask].reshape(-1, 1))
+    score = mutual_info_regression(x_scaled, b[mask], discrete_features=False, random_state=0)
+    return float(score[0])
+
+
+def _rolling_consistency(df: pd.DataFrame, window: int = 20, threshold: float = 0.3) -> pd.DataFrame:
+    cols = df.columns
+    hits = pd.DataFrame(0.0, index=cols, columns=cols)
+    total = 0
+    for end in range(window, len(df) + 1):
+        subset = df.iloc[end - window : end]
+        corr = subset.corr().abs()
+        hits = hits.add((corr >= threshold).astype(float), fill_value=0.0)
+        total += 1
+    return hits / total if total else hits
+
+
+def _granger(df: pd.DataFrame, maxlag: int = 4) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    cols = df.columns
+    pvals = pd.DataFrame(np.nan, index=cols, columns=cols)
+    clean = df.dropna()
+    for a, b in itertools.permutations(cols, 2):
+        try:
+            tests = grangercausalitytests(clean[[b, a]], maxlag=maxlag, verbose=False)
+            pvals.loc[a, b] = min(result[0]["ssr_ftest"][1] for result in tests.values())
+        except Exception:
+            continue
+    flat = pvals.values.flatten()
+    mask = ~np.isnan(flat)
+    decisions = np.zeros_like(flat, dtype=bool)
+    if mask.sum():
+        decisions[mask] = multipletests(flat[mask], alpha=0.05, method="fdr_bh")[0]
+    significant = pd.DataFrame(decisions.reshape(pvals.shape), index=pvals.index, columns=pvals.columns)
+    return pvals, significant
+
+
+def discover_all(
+    wide: pd.DataFrame,
+    corr_thr_strong: float = 0.45,
+    corr_thr_medium: float = 0.30,
+    maxlag: int = 4,
+) -> pd.DataFrame:
+    dense = wide.dropna(axis=1, how="any").dropna()
+    if dense.shape[1] < 3:
+        return pd.DataFrame(columns=["a", "b", "corr", "pcorr", "mi", "consistency", "gr_ab", "gr_ba", "score", "tier"])
+
+    corr = dense.corr()
+    pcorr = _partial_corr(dense).reindex_like(corr).fillna(0.0)
+    pvals, gr_sig = _granger(dense, maxlag=maxlag)
+    consistency = _rolling_consistency(dense, window=min(20, max(6, len(dense) // 5)), threshold=corr_thr_medium)
+
+    results = []
+    cols = list(dense.columns)
+    for i in range(len(cols)):
+        for j in range(i + 1, len(cols)):
+            a, b = cols[i], cols[j]
+            corr_val = float(corr.loc[a, b])
+            pcorr_val = float(pcorr.loc[a, b]) if a in pcorr.index and b in pcorr.columns else 0.0
+            mi_val = _mi(dense[a].values, dense[b].values)
+            g_ab = bool(gr_sig.loc[a, b]) if a in gr_sig.index and b in gr_sig.columns else False
+            g_ba = bool(gr_sig.loc[b, a]) if b in gr_sig.index and a in gr_sig.columns else False
+            cons_val = float(consistency.loc[a, b]) if a in consistency.index and b in consistency.columns else 0.0
+            score = (
+                abs(corr_val)
+                + 0.5 * abs(pcorr_val)
+                + 0.3 * mi_val
+                + 0.2 * (g_ab + g_ba)
+                + 0.3 * cons_val
+            )
+            tier = "strong" if abs(corr_val) >= corr_thr_strong else "medium" if abs(corr_val) >= corr_thr_medium else "weak"
+            results.append(
+                {
+                    "a": a,
+                    "b": b,
+                    "corr": corr_val,
+                    "pcorr": pcorr_val,
+                    "mi": mi_val,
+                    "consistency": cons_val,
+                    "gr_ab": g_ab,
+                    "gr_ba": g_ba,
+                    "score": score,
+                    "tier": tier,
+                }
+            )
+    return pd.DataFrame(results).sort_values("score", ascending=False)

--- a/src/features.py
+++ b/src/features.py
@@ -1,20 +1,80 @@
-"""Feature engineering helpers for the discovery stage."""
+"""Feature engineering helpers for normalised observation tables."""
 
 from __future__ import annotations
 
 import pandas as pd
+import numpy as np
+
+from .store import con
+from .qc import basic_qc
 
 
-def build_wide(df_obs: pd.DataFrame, limit: int = 600) -> pd.DataFrame:
-    """Return a wide pivoted dataframe from normalised observations."""
+def load_obs(limit: int = 1200) -> pd.DataFrame:
+    """Load the longest logical series from the obs table."""
 
-    df = df_obs.copy()
+    connection = con()
+    try:
+        df = connection.execute("SELECT series_key, period, value FROM obs").df()
+    finally:
+        connection.close()
+    if df.empty:
+        return df
     df["logical_name"] = df["series_key"].str.split("|").str[0]
-    counts = df.groupby("logical_name")["period"].nunique().sort_values(ascending=False)
-    keep = counts.head(limit).index
+    lengths = df.groupby("logical_name")["period"].nunique().sort_values(ascending=False)
+    keep = lengths.head(limit).index
+    return df[df["logical_name"].isin(keep)]
+
+
+def pivot_wide(df_obs: pd.DataFrame) -> pd.DataFrame:
+    """Pivot observations into a period-indexed wide matrix."""
+
+    if df_obs.empty:
+        return pd.DataFrame()
     wide = (
-        df[df["logical_name"].isin(keep)]
-        .pivot_table(index="period", columns="logical_name", values="value")
+        df_obs.pivot_table(index="period", columns="logical_name", values="value")
         .sort_index()
     )
     return wide.interpolate(limit_direction="both")
+
+
+def add_derivatives(wide: pd.DataFrame) -> pd.DataFrame:
+    """Append derivative indicators such as YoY growth, spreads, and ratios."""
+
+    out = wide.copy()
+    if len(out) > 12:
+        yoy = out.pct_change(12)
+        yoy.columns = [f"{col}__yoy" for col in out.columns]
+        out = pd.concat([out, yoy], axis=1)
+    if len(out) > 4:
+        qoq4 = out.pct_change(4)
+        qoq4.columns = [f"{col}__q4" for col in out.columns]
+        out = pd.concat([out, qoq4], axis=1)
+
+    def _maybe(name: str) -> list[str]:
+        lower = name.lower()
+        return [col for col in out.columns if lower in col.lower()]
+
+    short = _maybe("short") + _maybe("3m")
+    long = _maybe("long") + _maybe("10y")
+    if short and long:
+        out["rates__term_spread"] = out[long[0]] - out[short[0]]
+
+    loans = _maybe("loan")
+    deposits = _maybe("deposit")
+    if loans and deposits:
+        denom = out[deposits[0]].replace(0, np.nan)
+        out["bank__loan_to_deposit"] = out[loans[0]] / denom
+    return out
+
+
+def build_wide(limit: int = 1200) -> pd.DataFrame:
+    """Construct a QC-ed wide matrix with engineered derivative features."""
+
+    obs = load_obs(limit=limit)
+    wide = pivot_wide(obs)
+    if wide.empty:
+        return wide
+    wide = basic_qc(wide, min_len=24)
+    wide = add_derivatives(wide)
+    wide = wide.loc[:, wide.notna().sum() > 0]
+    return wide

--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -1,0 +1,60 @@
+"""Utilities for fetching data payloads using catalog rows."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from .kosis_api import data_by_params, data_by_userstats, get_meta_table
+from .validator import normalize_range
+
+
+def fetch_row(row: Dict[str, Any]) -> pd.DataFrame:
+    """Fetch a dataframe for a single catalog row."""
+
+    prd_se = str(row.get("prdSe", "")).strip()
+    start, end = normalize_range(
+        prd_se, row.get("startPrdDe") or None, row.get("endPrdDe") or None
+    )
+
+    mode = row.get("mode")
+    if not mode:
+        mode = "user" if row.get("userStatsId") else "param"
+
+    if mode == "user":
+        data = data_by_userstats(
+            user_stats_id=str(row["userStatsId"]),
+            prd_se=prd_se,
+            start=start,
+            end=end,
+            newEstPrdCnt=row.get("newEstPrdCnt") or None,
+            prdInterval=row.get("prdInterval") or None,
+            outputFields=row.get("outputFields") or "PRD_DE,DT,UNIT_NM",
+        )
+    else:
+        obj = {
+            key: str(row[key])
+            for key in [f"objL{i}" for i in range(1, 9)]
+            if key in row and str(row[key]).strip() != ""
+        }
+        data = data_by_params(
+            org_id=str(row["orgId"]),
+            tbl_id=str(row["tblId"]),
+            prd_se=prd_se,
+            obj=obj,
+            itm_id=str(row["itmId"]),
+            start=start,
+            end=end,
+            newEstPrdCnt=row.get("newEstPrdCnt") or None,
+            prdInterval=row.get("prdInterval") or None,
+            outputFields=row.get("outputFields") or "PRD_DE,DT,UNIT_NM",
+        )
+
+    return pd.DataFrame(data)
+
+
+def enrich_with_meta_if_needed(org_id: str, tbl_id: str) -> Dict[str, Any]:
+    """Fetch table metadata (classification/item definitions) when required."""
+
+    return get_meta_table(org_id, tbl_id)

--- a/src/io_helpers.py
+++ b/src/io_helpers.py
@@ -1,0 +1,21 @@
+"""Small IO helpers for catalog/data persistence."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pandas as pd
+import yaml
+
+
+def save_csv(df: pd.DataFrame, path: str) -> None:
+    """Persist a dataframe to CSV without the index."""
+
+    df.to_csv(path, index=False)
+
+
+def save_yaml(series: List[Dict[str, Any]], path: str) -> None:
+    """Persist the provided series descriptors to YAML."""
+
+    with open(path, "w", encoding="utf-8") as file:
+        yaml.safe_dump({"series": series}, file, allow_unicode=True, sort_keys=False)

--- a/src/kosis_api.py
+++ b/src/kosis_api.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
-from .config import KOSIS_API_KEY, URL_DATA, URL_LIST, URL_PARAM
+from .config import KOSIS_API_KEY, URL_DATA, URL_LIST, URL_META, URL_PARAM
 from .utils import get_json
 
 
-def list_stats(vw_cd: str, parent_list_id: str, jsonVD: str = "Y") -> Any:
+def list_stats(vw_cd: str, parent_list_id: str, jsonVD: str = "Y") -> List[Dict[str, Any]]:
     """Retrieve a statistics list for the provided view and parent list."""
 
     params = {
@@ -64,7 +64,7 @@ def data_by_params(
     newEstPrdCnt: Optional[int] = None,
     prdInterval: Optional[int] = None,
     outputFields: str = "PRD_DE,DT,UNIT_NM",
-) -> Any:
+) -> List[Dict[str, Any]]:
     """Retrieve statistics data for the parameterised table endpoint."""
 
     params: Dict[str, Any] = {
@@ -89,4 +89,22 @@ def data_by_params(
         params["prdInterval"] = prdInterval
     if outputFields:
         params["outputFields"] = outputFields
+    if not any(key for key in params if key.lower().startswith("objl")):
+        raise ValueError("Param API 호출 시 objL1~objL8 중 최소 1개가 필요합니다.")
+    if not itm_id:
+        raise ValueError("Param API 호출 시 itmId는 필수입니다.")
     return get_json(URL_PARAM, params)
+
+
+def get_meta_table(org_id: str, tbl_id: str) -> Dict[str, Any]:
+    """Fetch table metadata for the supplied organisation/table identifiers."""
+
+    params = {
+        "method": "getMeta",
+        "apiKey": KOSIS_API_KEY,
+        "format": "json",
+        "type": "TBL",
+        "orgId": org_id,
+        "tblId": tbl_id,
+    }
+    return get_json(URL_META, params)

--- a/src/normalize.py
+++ b/src/normalize.py
@@ -1,62 +1,88 @@
-"""Normalisation helpers for aligning KOSIS payloads to the obs table."""
+"""Payload normalisation helpers for KOSIS observations."""
 
 from __future__ import annotations
 
 import json
 import re
-from typing import Iterable
+from typing import Dict, List
 
 import pandas as pd
 
+from .validator import validate_prdse
 from .store import upsert_obs
 
-
-def period_to_anchor(prd_de: str, prd_se: str) -> tuple[str, str]:
-    """Convert KOSIS period descriptors into ISO date anchors and frequency codes."""
-
-    digits = re.sub(r"[^0-9]", "", str(prd_de))
-    if prd_se == "M":
-        period = pd.Period(f"{digits[:4]}-{digits[4:6]}", freq="M").to_timestamp("M").strftime("%Y-%m-%d")
-        return period, "M"
-    if prd_se == "Q":
-        year, quarter = digits[:4], digits[-1]
-        period = pd.Period(f"{year}Q{quarter}", freq="Q").to_timestamp("Q").strftime("%Y-%m-%d")
-        return period, "Q"
-    if prd_se == "Y":
-        period = pd.Period(digits[:4], freq="A").to_timestamp("A").strftime("%Y-%m-%d")
-        return period, "Y"
-    return digits, prd_se
+# Canonical field aliases encountered in KOSIS payloads.
+VAL_KEYS = ["DT", "DATA_VALUE", "value", "dt"]
+PERD_KEYS = ["PRD_DE", "prdDe", "period"]
+UNIT_KEYS = ["UNIT_NM", "UNIT_NM_ENG", "unit", "unitName"]
 
 
-def flatten_payload(logical_name: str, rows: Iterable[dict], prd_se: str) -> pd.DataFrame:
-    """Flatten the raw payload rows into the obs schema."""
+def _pick(payload: Dict, keys: List[str], default=None):
+    for key in keys:
+        if key in payload and payload[key] not in (None, ""):
+            return payload[key]
+    return default
 
-    records = []
+
+def _anchor_from_prd(prd_de: str, prd_se: str) -> tuple[str, str]:
+    """Derive an ISO anchor date and frequency flag from the period descriptor."""
+
+    cleaned = re.sub(r"[^0-9Qq]", "", str(prd_de))
+    if prd_se == "M" and len(cleaned) >= 6:
+        period = pd.Period(f"{cleaned[:4]}-{cleaned[4:6]}", freq="M").to_timestamp("M")
+        return period.strftime("%Y-%m-%d"), "M"
+    if prd_se == "Q" and len(cleaned) >= 5:
+        match = re.match(r"^(\d{4})[Qq]([1-4])$", cleaned)
+        if not match and len(cleaned) >= 6:
+            year, quarter = cleaned[:4], cleaned[-1]
+            candidate = f"{year}Q{quarter}"
+            match = re.match(r"^(\d{4})Q([1-4])$", candidate)
+        if match:
+            year, quarter = match.groups()
+            period = pd.Period(f"{year}Q{quarter}", freq="Q").to_timestamp("Q")
+            return period.strftime("%Y-%m-%d"), "Q"
+    if prd_se == "Y" and len(cleaned) >= 4:
+        period = pd.Period(cleaned[:4], freq="A").to_timestamp("A")
+        return period.strftime("%Y-%m-%d"), "Y"
+    return cleaned, prd_se
+
+
+def normalize_payload(logical_name: str, rows: List[Dict], prd_se: str) -> pd.DataFrame:
+    """Convert raw payload rows into the canonical observation schema."""
+
+    validate_prdse(prd_se)
+    records: List[Dict] = []
     for row in rows:
-        period_value = row.get("PRD_DE") or row.get("prdDe")
-        value = row.get("DT") or row.get("DATA_VALUE") or row.get("value")
-        unit = row.get("UNIT_NM") or row.get("UNIT_NM_ENG") or ""
-        if period_value is None or value in (None, ""):
+        period_raw = _pick(row, PERD_KEYS)
+        value_raw = _pick(row, VAL_KEYS)
+        unit = _pick(row, UNIT_KEYS, default="")
+        if period_raw in (None, "") or value_raw in (None, ""):
             continue
-        period, freq = period_to_anchor(str(period_value), prd_se)
-        dims = {key: val for key, val in row.items() if key not in ("PRD_DE", "DT")}
+        try:
+            value = float(str(value_raw).replace(",", ""))
+        except Exception:
+            continue
+        period, freq = _anchor_from_prd(period_raw, prd_se)
+        dims = {k: v for k, v in row.items() if k not in set(PERD_KEYS + VAL_KEYS)}
         series_key = logical_name + "|" + json.dumps(dims, ensure_ascii=False, sort_keys=True)
         records.append(
             {
                 "series_key": series_key,
                 "period": period,
                 "freq": freq,
-                "value": float(value),
+                "value": value,
                 "unit": unit,
                 "dims": json.dumps(dims, ensure_ascii=False),
             }
         )
-    return pd.DataFrame(records)
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df = df.drop_duplicates(subset=["series_key", "period"]).sort_values(["series_key", "period"])
+    return df
 
 
-def normalize_and_store(logical_name: str, payload_rows: Iterable[dict], prd_se: str) -> None:
-    """Normalise the supplied payload and persist the resulting observations."""
+def store_obs(df_norm: pd.DataFrame) -> None:
+    """Persist normalised observations when available."""
 
-    frame = flatten_payload(logical_name, payload_rows, prd_se)
-    if not frame.empty:
-        upsert_obs(frame)
+    if not df_norm.empty:
+        upsert_obs(df_norm)

--- a/src/qc.py
+++ b/src/qc.py
@@ -1,0 +1,22 @@
+"""Lightweight quality-control helpers for wide observation matrices."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def basic_qc(wide: pd.DataFrame, min_len: int = 24, max_na_ratio: float = 0.2, min_std: float = 1e-8) -> pd.DataFrame:
+    """Filter columns failing simple length, missingness, or variance checks."""
+
+    keep = []
+    for column in wide.columns:
+        series = wide[column]
+        valid = series.dropna()
+        if len(valid) < min_len:
+            continue
+        if series.isna().mean() > max_na_ratio:
+            continue
+        if valid.std(ddof=0) < min_std:
+            continue
+        keep.append(column)
+    return wide[keep]

--- a/src/validator.py
+++ b/src/validator.py
@@ -1,0 +1,54 @@
+"""Validation helpers for KOSIS period parameters."""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+# prdSe 허용: Y(연), M(월), Q(분기), S(반기), D(일), F(수시), IR(부정기) 등
+VALID_PRDSE = {"Y", "M", "Q", "S", "D", "F", "IR"}
+
+
+def validate_prdse(prd_se: str) -> None:
+    """Ensure the provided ``prdSe`` value matches the official whitelist."""
+
+    if prd_se not in VALID_PRDSE:
+        raise ValueError(
+            f"prdSe가 올바르지 않습니다: {prd_se} (허용: {sorted(VALID_PRDSE)})"
+        )
+
+
+def normalize_period_str(prd_se: str, yyyx: str) -> str:
+    """Normalize the period string according to the KOSIS specification."""
+
+    s = re.sub(r"[^0-9Qq]", "", str(yyyx))
+    if prd_se == "Q":
+        match = re.match(r"^(\d{4})[Qq]([1-4])$", s)
+        if not match:
+            raise ValueError(
+                f"분기 prdSe=Q는 YYYYQ[1-4] 형식이어야 합니다: {yyyx}"
+            )
+        return f"{match.group(1)}Q{match.group(2)}"
+    if prd_se == "M":
+        match = re.match(r"^(\d{4})(0[1-9]|1[0-2])$", s)
+        if not match:
+            raise ValueError(f"월 prdSe=M은 YYYYMM 형식이어야 합니다: {yyyx}")
+        return f"{match.group(1)}{match.group(2)}"
+    if prd_se == "Y":
+        match = re.match(r"^(\d{4})$", s)
+        if not match:
+            raise ValueError(f"연 prdSe=Y는 YYYY 형식이어야 합니다: {yyyx}")
+        return match.group(1)
+    # S/D/F/IR 등은 데이터셋별 케이스가 다양 → 우선 원본 유지(필요 시 확장)
+    return yyyx
+
+
+def normalize_range(
+    prd_se: str, start: str | None = None, end: str | None = None
+) -> Tuple[str | None, str | None]:
+    """Normalize start/end period strings using the validation helpers."""
+
+    validate_prdse(prd_se)
+    ns = normalize_period_str(prd_se, start) if start else None
+    ne = normalize_period_str(prd_se, end) if end else None
+    return ns, ne


### PR DESCRIPTION
## Summary
- add a normalisation module that standardises KOSIS payloads, anchors periods, and persists observations into DuckDB
- build feature engineering helpers, QC filters, and step 2 orchestration for producing derivative-rich wide matrices
- extend the discovery stage with partial correlations, Granger causality, mutual information scoring, and command-line automation plus supporting config/dependency updates

## Testing
- python -m compileall src run_step2_prepare.py run_step3_discover.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b7a32304832d9ea0495bb0fce071