### PR TITLE
Implement scenario DSL and engine

### DIFF
--- a/run_step5_scenario.py
+++ b/run_step5_scenario.py
@@ -1,12 +1,52 @@
-"""Step 5: Apply user-defined scenarios to causal responses."""
-
 from __future__ import annotations
 
-from src import scenario, store
+import argparse
+import os
+from pathlib import Path
+
+from src.io_utils import load_irf_csv, load_lp_betas, read_yaml, save_csv, save_md
+from src.scenario_dsl import validate_and_expand
+from src.scenario_engine import apply_irf, summarize_effects
+from src.scenario_post import render_markdown, sectionize
 
 
-# TODO: flesh out the scenario DSL (step/pulse/gradual/path) and integrate with impulse responses.
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", required=True, help="YAML 파일 경로")
+    ap.add_argument("--irf", default="out_causal/irf_svar.csv", help="IRF csv (없으면 irf_var.csv 사용)")
+    ap.add_argument("--fallback-irf", default="out_causal/irf_var.csv")
+    ap.add_argument("--lp", default="out_causal/lp_betas.csv")
+    ap.add_argument("--outdir", default="out_scenario")
+    ap.add_argument("--summary-h", type=int, default=4)
+    args = ap.parse_args()
+
+    Path(args.outdir).mkdir(parents=True, exist_ok=True)
+
+    spec = read_yaml(args.scenario)
+    scn = validate_and_expand(spec)
+    name = scn.get("meta", {}).get("name", os.path.basename(args.scenario))
+
+    irf_path = args.irf if os.path.exists(args.irf) else args.fallback_irf
+    irf_df = load_irf_csv(irf_path)
+
+    eff_df = apply_irf(irf_df, scn)
+    save_csv(eff_df, os.path.join(args.outdir, "effects_full.csv"))
+
+    summ = summarize_effects(eff_df, horizon_pick=args.summary_h)
+    save_csv(summ, os.path.join(args.outdir, f"summary_h{args.summary_h}.csv"))
+
+    sect = sectionize(eff_df, h_pick=args.summary_h)
+    for sec, df in sect.items():
+        save_csv(df, os.path.join(args.outdir, f"{sec.lower()}_h{args.summary_h}.csv"))
+
+    lp_df = load_lp_betas(args.lp)
+    if lp_df is not None:
+        save_csv(lp_df, os.path.join(args.outdir, "lp_betas_copy.csv"))
+
+    md = render_markdown(name, args.summary_h, sect)
+    save_md(os.path.join(args.outdir, "report.md"), md)
+    print(f"[scenario] '{name}' done → {args.outdir}")
+
 
 if __name__ == "__main__":
-    store.init()
-    print("Scenario stage placeholder. Extend apply_scenario with DSL semantics.")
+    main()

--- a/run_step6_report.py
+++ b/run_step6_report.py
@@ -1,23 +1,48 @@
-"""Step 6: Generate the final multi-section report."""
-
 from __future__ import annotations
 
+import argparse
+import os
 from pathlib import Path
 
-import pandas as pd
+from src.report6_assembler import assemble
+from src.report6_io import (
+    load_irf,
+    load_lp,
+    load_scenario_effects,
+    load_signals,
+    load_stationarity,
+)
+from src.report6_render import render_html, render_markdown
 
-from src import report, store
 
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--signals", default="out_signals.csv")
+    parser.add_argument("--irf-svar", dest="irf_svar", default="out_causal/irf_svar.csv")
+    parser.add_argument("--irf-var", dest="irf_var", default="out_causal/irf_var.csv")
+    parser.add_argument("--lp", default="out_causal/lp_betas.csv")
+    parser.add_argument("--stationarity", default="out_causal/stationarity_report.csv")
+    parser.add_argument("--scenario-dir", default="out_scenario")
+    parser.add_argument("--outdir", default="out_report")
+    parser.add_argument("--h-pick", type=int, default=4, help="시나리오 요약 시차(h)")
+    args = parser.parse_args()
 
-# TODO: source discovery outputs and call report.render_quad8 with enriched context.
+    Path(args.outdir).mkdir(parents=True, exist_ok=True)
+
+    pairs = load_signals(args.signals)
+    irf = load_irf(args.irf_svar, args.irf_var)
+    lp = load_lp(args.lp)
+    _stationarity = load_stationarity(args.stationarity)
+    scenario = load_scenario_effects(args.scenario_dir)
+
+    bundle = assemble(pairs, irf, lp, scenario, h_pick=args.h_pick)
+
+    md_path = os.path.join(args.outdir, "report.md")
+    render_markdown(bundle, md_path)
+    render_html(md_path, os.path.join(args.outdir, "report.html"))
+
+    print(f"[report] done → {args.outdir}/report.md (and .html)")
+
 
 if __name__ == "__main__":
-    store.init()
-    output_path = Path("report.md")
-    dummy = pd.DataFrame(
-        [
-            {"a": "gdp.real", "b": "cpi.headline", "corr": 0.42, "tier": "medium", "score": 0.42},
-        ]
-    )
-    report.render_quad8(str(output_path), dummy)
-    print(f"Report stage placeholder. Wrote {output_path} with sample content.")
+    main()

--- a/scenarios/example_basic.yaml
+++ b/scenarios/example_basic.yaml
@@ -1,0 +1,27 @@
+meta:
+  name: "금리+환율 복합 긴축"
+  horizon: 8
+  units: "model"
+
+shocks:
+  - var: "macro.policy_rate"
+    type: "step"
+    size: 0.50
+    start_h: 0
+  - var: "fx.usdkrw"
+    type: "gradual"
+    size: 0.08
+    start_h: 1
+    duration: 4
+  - var: "energy.oil"
+    type: "pulse"
+    size: 0.10
+    start_h: 0
+    duration: 1
+
+targets:
+  include_prefix:
+    - "macro."
+    - "firm."
+    - "finance."
+    - "asset."

--- a/scenarios/example_path.yaml
+++ b/scenarios/example_path.yaml
@@ -1,0 +1,18 @@
+meta:
+  name: "정책금리 경로 제시 (경로 고정)"
+  horizon: 8
+
+shocks:
+  - var: "macro.policy_rate"
+    type: "path"
+    path: [0.25, 0.25, 0.00, -0.25, -0.25, 0.00, 0.00, 0.00]
+    start_h: 0
+
+targets:
+  include_prefix:
+    - "macro."
+    - "firm."
+    - "finance."
+    - "asset."
+    - "real_estate."
+    - "debt."

--- a/src/io_utils.py
+++ b/src/io_utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+import yaml
+
+
+def read_yaml(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def save_md(path: str, text: str) -> None:
+    Path(os.path.dirname(path)).mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+def save_csv(df: pd.DataFrame, path: str) -> None:
+    Path(os.path.dirname(path)).mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def load_irf_csv(irf_path: str) -> pd.DataFrame:
+    df = pd.read_csv(irf_path)
+    must = {"shock", "target", "h", "resp"}
+    if not must.issubset(set(df.columns)):
+        raise ValueError(f"IRF csv schema mismatch: need {must}, got {df.columns}")
+    return df
+
+
+def load_lp_betas(path: str) -> pd.DataFrame | None:
+    if not os.path.exists(path):
+        return None
+    return pd.read_csv(path)

--- a/src/report6_assembler.py
+++ b/src/report6_assembler.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .report6_quality import attach_reliability, kpi_summary
+from .report6_sections import add_section_cols, top_cross_domain, top_by_section
+
+
+def assemble(
+    pairs: pd.DataFrame,
+    irf: pd.DataFrame | None,
+    lp: pd.DataFrame | None,
+    scenario: dict[str, object] | None,
+    h_pick: int = 4,
+) -> Dict[str, object]:
+    """Aggregate inputs into the structures required for the final report."""
+
+    # 1) Attach reliability metrics and section routing
+    pairs_with_reliability = attach_reliability(pairs)
+    pairs_with_sections = add_section_cols(pairs_with_reliability)
+    kpi = kpi_summary(pairs_with_reliability)
+
+    # 2) Cross-domain and per-section leaders
+    cross_top = top_cross_domain(pairs_with_sections, top=15)
+    section_top = top_by_section(pairs_with_sections, top=12)
+
+    # 3) IRF highlights @ selected horizons
+    irf_highlights = pd.DataFrame()
+    if irf is not None and not irf.empty:
+        irf_copy = irf.copy()
+        irf_copy["abs"] = irf_copy["resp"].abs()
+        irf_highlights = (
+            irf_copy[irf_copy["h"].isin([1, 2, 4, 8])]  # typical horizons
+            .sort_values("abs", ascending=False)
+            .groupby("h")
+            .head(10)
+        )
+
+    # 4) Local projection betas (investment tilt)
+    lp_top = pd.DataFrame()
+    if lp is not None and not lp.empty:
+        if "beta_h4" in lp.columns:
+            lp_top = (
+                lp.assign(abs4=lp["beta_h4"].abs())
+                .sort_values("abs4", ascending=False)
+                .head(12)
+            )
+
+    # 5) Scenario effects summary
+    scenario = scenario or {}
+    scn_summary = pd.DataFrame()
+    effects_full = scenario.get("effects_full") if isinstance(scenario, dict) else None
+    if effects_full is not None and not effects_full.empty:
+        pick = effects_full[(effects_full["h"] == h_pick) & (effects_full["source"] == "mix")].copy()
+        pick["abs"] = pick["effect"].abs()
+        scn_summary = pick.sort_values("abs", ascending=False).head(15)
+
+    return {
+        "pairs": pairs_with_sections,
+        "kpi": kpi,
+        "cross_top": cross_top,
+        "sec_top": section_top,
+        "irf_top": irf_highlights,
+        "lp_top": lp_top,
+        "scn_summary": scn_summary,
+    }

--- a/src/report6_io.py
+++ b/src/report6_io.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import pandas as pd
+
+
+def load_signals(path: str = "out_signals.csv") -> pd.DataFrame:
+    """Load signal pairs data, ensuring optional columns exist."""
+
+    if not os.path.exists(path):
+        return pd.DataFrame(
+            columns=[
+                "a",
+                "b",
+                "corr",
+                "pcorr",
+                "mi",
+                "consistency",
+                "gr_ab",
+                "gr_ba",
+                "score",
+                "tier",
+            ]
+        )
+
+    df = pd.read_csv(path)
+    for col in ["pcorr", "mi", "consistency", "gr_ab", "gr_ba", "score", "tier"]:
+        if col not in df.columns:
+            df[col] = None
+    return df
+
+
+def load_irf(
+    path_svar: str = "out_causal/irf_svar.csv", path_var: str = "out_causal/irf_var.csv"
+) -> pd.DataFrame:
+    """Load impulse response functions, preferring SVAR if available."""
+
+    target = path_svar if os.path.exists(path_svar) else path_var
+    if not os.path.exists(target):
+        return pd.DataFrame(columns=["shock", "target", "h", "resp"])
+    return pd.read_csv(target)
+
+
+def load_lp(path: str = "out_causal/lp_betas.csv") -> pd.DataFrame | None:
+    return pd.read_csv(path) if os.path.exists(path) else None
+
+
+def load_stationarity(path: str = "out_causal/stationarity_report.csv") -> pd.DataFrame | None:
+    return pd.read_csv(path) if os.path.exists(path) else None
+
+
+def load_scenario_effects(dirpath: str = "out_scenario") -> dict[str, object]:
+    """Load scenario effects and any per-section summaries if present."""
+
+    data: dict[str, object] = {
+        "effects_full": pd.DataFrame(),
+        "summaries": {},
+        "per_section": {},
+    }
+
+    effects_path = os.path.join(dirpath, "effects_full.csv")
+    if os.path.exists(effects_path):
+        data["effects_full"] = pd.read_csv(effects_path)
+
+    if not os.path.exists(dirpath):
+        return data  # nothing else to load
+
+    for fname in os.listdir(dirpath):
+        fpath = os.path.join(dirpath, fname)
+        if not fname.endswith(".csv") or not os.path.isfile(fpath):
+            continue
+        if fname.startswith("summary_h"):
+            data["summaries"][fname] = pd.read_csv(fpath)
+            continue
+
+        stem = fname[:-4]
+        if any(
+            stem.startswith(prefix)
+            for prefix in [
+                "economy_",
+                "corporate_",
+                "finance_",
+                "real estate_",
+                "debt_",
+                "growth_",
+                "investment_",
+                "assets_",
+            ]
+        ):
+            data["per_section"][stem] = pd.read_csv(fpath)
+
+    return data

--- a/src/report6_quality.py
+++ b/src/report6_quality.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def reliability_from_signals(row: pd.Series) -> float:
+    """Composite reliability score combining multiple signal statistics."""
+
+    corr = abs(float(row.get("corr", 0) or 0))
+    pcorr = abs(float(row.get("pcorr", 0) or 0))
+    mi = float(row.get("mi", 0) or 0)
+    consistency = float(row.get("consistency", 0) or 0)
+    granger = 1.0 if (bool(row.get("gr_ab", False)) or bool(row.get("gr_ba", False))) else 0.0
+    score = 0.35 * corr + 0.20 * pcorr + 0.15 * mi + 0.20 * consistency + 0.10 * granger
+    return max(0.0, min(1.0, score))
+
+
+def label_from_reliability(x: float) -> str:
+    if x >= 0.66:
+        return "High"
+    if x >= 0.4:
+        return "Med"
+    return "Low"
+
+
+def attach_reliability(df_pairs: pd.DataFrame) -> pd.DataFrame:
+    if df_pairs is None or df_pairs.empty:
+        return df_pairs
+    enriched = df_pairs.copy()
+    enriched["reliability"] = enriched.apply(reliability_from_signals, axis=1)
+    enriched["reliability_label"] = enriched["reliability"].apply(label_from_reliability)
+    return enriched
+
+
+def kpi_summary(pairs: pd.DataFrame) -> dict:
+    if pairs is None or pairs.empty:
+        return {"n_pairs": 0, "share_strong": 0, "share_med": 0, "avg_reliability": 0}
+
+    n_pairs = len(pairs)
+    strong = (pairs["tier"] == "strong").sum() if "tier" in pairs.columns else 0
+    medium = (pairs["tier"] == "medium").sum() if "tier" in pairs.columns else 0
+
+    reliability = (
+        pairs["reliability"].mean()
+        if "reliability" in pairs.columns and not pairs["reliability"].isna().all()
+        else 0
+    )
+
+    return {
+        "n_pairs": n_pairs,
+        "share_strong": round(strong / n_pairs, 3) if n_pairs else 0,
+        "share_med": round(medium / n_pairs, 3) if n_pairs else 0,
+        "avg_reliability": round(float(reliability), 3) if n_pairs else 0,
+    }

--- a/src/report6_render.py
+++ b/src/report6_render.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from .report6_utils import fmt_float
+
+
+def _pairs_to_md(df: pd.DataFrame) -> list[str]:
+    lines: list[str] = []
+    if df is None or df.empty:
+        lines.append("- (no items)")
+        return lines
+    for _, row in df.iterrows():
+        corr = fmt_float(row.get("corr"))
+        cons = fmt_float(row.get("consistency"))
+        label = row.get("reliability_label", "")
+        lines.append(
+            f"- **{row['a']}** ↔ **{row['b']}**: corr {corr}, cons {cons} · {label}"
+        )
+    return lines
+
+
+def _lp_to_md(df: pd.DataFrame) -> list[str]:
+    lines: list[str] = []
+    if df is None or df.empty:
+        return ["- (no LP betas)"]
+    for _, row in df.iterrows():
+        name = row.get("target", "")
+        beta4 = fmt_float(row.get("beta_h4"))
+        lines.append(f"- {name}: β@h4={beta4}")
+    return lines
+
+
+def _irf_to_md(df: pd.DataFrame) -> list[str]:
+    lines: list[str] = []
+    if df is None or df.empty:
+        return ["- (no IRF)"]
+    for _, row in df.iterrows():
+        lines.append(
+            f"- {row['shock']} → {row['target']} @h={int(row['h'])}: {fmt_float(row['resp'])}"
+        )
+    return lines
+
+
+def _scn_to_md(df: pd.DataFrame) -> list[str]:
+    lines: list[str] = []
+    if df is None or df.empty:
+        return ["- (no scenario effects)"]
+    for _, row in df.iterrows():
+        lines.append(f"- {row['target']}: Δ {fmt_float(row['effect'])}")
+    return lines
+
+
+def render_markdown(bundle: dict, out_md: str) -> None:
+    Path(os.path.dirname(out_md)).mkdir(parents=True, exist_ok=True)
+    kpi = bundle["kpi"]
+    md: list[str] = []
+    md.append("# KOSIS Cross-Domain Intelligence — Final Report")
+    md.append(f"_Generated: {datetime.now().isoformat()}_  \n")
+    md.append(
+        "**Coverage**: "
+        f"pairs={kpi['n_pairs']} · "
+        f"strong={kpi['share_strong'] * 100:.1f}% · "
+        f"medium={kpi['share_med'] * 100:.1f}% · "
+        f"reliability(avg)={kpi['avg_reliability']}"
+    )
+    md.append("\n---\n")
+    md.append("## Executive Summary")
+    md.extend(
+        [
+            "- 최상위 Cross-Domain 5개, IRF/시나리오 하이라이트, 투자 틸트(요약)를 아래 섹션에서 확인하세요.",
+            "",
+        ]
+    )
+    md.append("## Cross-Domain Insights (Top)")
+    md.extend(_pairs_to_md(bundle["cross_top"].head(12)))
+    md.append("")
+
+    md.append("## Sections")
+    for section in [
+        "Economy",
+        "Corporate",
+        "Finance",
+        "Real Estate",
+        "Debt",
+        "Growth",
+        "Investment",
+        "Assets",
+    ]:
+        md.append(f"### {section}")
+        md.extend(_pairs_to_md(bundle["sec_top"].get(section)))
+        md.append("")
+
+    md.append("## IRF Highlights")
+    md.extend(_irf_to_md(bundle["irf_top"]))
+    md.append("")
+
+    md.append("## Investment Tilt (Local Projections β)")
+    md.extend(_lp_to_md(bundle["lp_top"]))
+    md.append("")
+
+    md.append("## Scenario Effects (@h=4 default)")
+    md.extend(_scn_to_md(bundle["scn_summary"]))
+    md.append("")
+
+    md.append("\n---\n_notes_: corr=상관, cons=롤링지속률, reliability=합성 신뢰도(High/Med/Low).")
+
+    with open(out_md, "w", encoding="utf-8") as f:
+        f.write("\n".join(md))
+
+
+def render_html(markdown_path: str, out_html: str) -> None:
+    Path(os.path.dirname(out_html)).mkdir(parents=True, exist_ok=True)
+    with open(markdown_path, "r", encoding="utf-8") as f:
+        md_content = f.read()
+
+    html = f"""<!doctype html>
+<html lang=\"ko\"><head>
+<meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+<title>KOSIS Final Report</title>
+<style>
+body{{font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans KR'; line-height:1.5; padding:24px; background:#f8fafc;}}
+h1,h2,h3{{margin-top:1.2em}}
+code,pre{{background:#0b1020; color:#e5e7eb; padding:12px; border-radius:8px; display:block; white-space:pre-wrap}}
+hr{{border:none; height:1px; background:#e2e8f0; margin:24px 0}}
+</style>
+</head><body>
+<pre>{md_content}</pre>
+</body></html>"""
+
+    with open(out_html, "w", encoding="utf-8") as f:
+        f.write(html)

--- a/src/report6_sections.py
+++ b/src/report6_sections.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pandas as pd
+
+SECTIONS = {
+    "Economy": ["macro.", "gdp", "cpi", "ppi", "trade", "fx", "population"],
+    "Corporate": ["firm.", "employment", "wage", "sales", "capex", "industry"],
+    "Finance": ["policy_rate", "m2", "credit", "spread", "loan_to_deposit", "bank_loan", "npl"],
+    "Investment": ["asset.", "etf", "reits", "bond", "gold"],
+    "Real Estate": ["real_estate.", "housing", "rent", "construction", "permit"],
+    "Debt": ["debt", "dsr", "dti", "leverage", "npl"],
+    "Growth": ["potential", "tfp", "productivity", "growth", "income", "consumption", "saving", "participation"],
+    "Assets": ["asset.", "fx.", "commodity.", "bond.", "equity."],
+}
+
+
+def route_section(name: str) -> str:
+    value = (name or "").lower()
+    for section, keys in SECTIONS.items():
+        if any(value.startswith(key) or key in value for key in keys):
+            return section
+    return "Assets"
+
+
+def add_section_cols(pairs: pd.DataFrame) -> pd.DataFrame:
+    if pairs is None or pairs.empty:
+        return pairs
+
+    df = pairs.copy()
+    df["a_sec"] = df["a"].map(route_section)
+    df["b_sec"] = df["b"].map(route_section)
+    df["same_section"] = df["a_sec"] == df["b_sec"]
+    df["section"] = df.apply(
+        lambda row: row["a_sec"] if row["same_section"] else "Cross-Domain", axis=1
+    )
+    return df
+
+
+def top_cross_domain(pairs_with_sec: pd.DataFrame, top: int = 15) -> pd.DataFrame:
+    if pairs_with_sec is None or pairs_with_sec.empty:
+        return pd.DataFrame(columns=pairs_with_sec.columns if pairs_with_sec is not None else [])
+
+    cross = pairs_with_sec[pairs_with_sec["section"] == "Cross-Domain"].copy()
+    if "reliability" in cross.columns:
+        cross["reliability"] = cross["reliability"].fillna(0.0)
+    if "score" in cross.columns:
+        cross["score"] = cross["score"].fillna(0.0)
+    if cross.empty:
+        return cross
+    return cross.sort_values(["reliability", "score"], ascending=False).head(top)
+
+
+def top_by_section(pairs_with_sec: pd.DataFrame, top: int = 12) -> dict[str, pd.DataFrame]:
+    out: dict[str, pd.DataFrame] = {}
+    for section in [
+        "Economy",
+        "Corporate",
+        "Finance",
+        "Real Estate",
+        "Debt",
+        "Growth",
+        "Investment",
+        "Assets",
+    ]:
+        if pairs_with_sec is None or pairs_with_sec.empty:
+            out[section] = pd.DataFrame()
+            continue
+
+        section_df = pairs_with_sec[pairs_with_sec["section"] == section].copy()
+        if section_df.empty:
+            out[section] = section_df
+        else:
+            if "reliability" in section_df.columns:
+                section_df["reliability"] = section_df["reliability"].fillna(0.0)
+            if "score" in section_df.columns:
+                section_df["score"] = section_df["score"].fillna(0.0)
+            out[section] = (
+                section_df.sort_values(["reliability", "score"], ascending=False).head(top)
+            )
+    return out

--- a/src/report6_utils.py
+++ b/src/report6_utils.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def fmt_float(x, nd: int = 3) -> str:
+    """Format numeric values safely for markdown/HTML output."""
+    try:
+        return f"{float(x):.{nd}f}"
+    except Exception:
+        return "-"

--- a/src/scenario_dsl.py
+++ b/src/scenario_dsl.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+
+VALID_TYPES = {"step", "pulse", "gradual", "path"}
+
+
+def validate_and_expand(spec: Dict[str, Any]) -> Dict[str, Any]:
+    meta = spec.get("meta", {})
+    Hz = int(meta.get("horizon", 8))
+    if Hz <= 0:
+        Hz = 8
+    shocks = spec.get("shocks", [])
+    out: List[Dict[str, Any]] = []
+    for s in shocks:
+        t = s.get("type", "step").lower()
+        if t not in VALID_TYPES:
+            raise ValueError(f"unknown shock type: {t}")
+        var = s["var"]
+        start = int(s.get("start_h", 0))
+        size = float(s.get("size", 0.0))
+        duration = int(s.get("duration", 1))
+        vec = np.zeros(Hz + 1)
+        if t == "step":
+            vec[start:] += size
+        elif t == "pulse":
+            end = min(start + duration, Hz + 1)
+            vec[start:end] += size
+        elif t == "gradual":
+            end = min(start + duration, Hz + 1)
+            if end <= start:
+                end = start + 1
+            steps = end - start
+            inc = np.linspace(0, size, steps)
+            vec[start:end] += inc
+            if end <= Hz:
+                vec[end:] += size
+        elif t == "path":
+            path = s.get("path", [])
+            for i, v in enumerate(path):
+                h = start + i
+                if h <= Hz:
+                    vec[h] += float(v)
+        out.append({"var": var, "type": t, "impulse": vec})
+    targets = spec.get("targets", {})
+    return {"horizon": Hz, "shocks": out, "targets": targets, "meta": meta}

--- a/src/scenario_engine.py
+++ b/src/scenario_engine.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+
+
+def _filter_targets(all_vars: List[str], targets_spec: Dict[str, Any]) -> List[str]:
+    inc = targets_spec.get("include", [])
+    pref = targets_spec.get("include_prefix", [])
+    exc = targets_spec.get("exclude", [])
+    out: List[str] = []
+    for v in all_vars:
+        if inc and v not in inc:
+            continue
+        if pref and not any(v.startswith(p) for p in pref):
+            continue
+        if exc and v in exc:
+            continue
+        if (not inc) and (not pref) and (v in exc):
+            continue
+        out.append(v)
+    if not inc and not pref:
+        out = [v for v in all_vars if v not in exc]
+    return out
+
+
+def apply_irf(irf_df: pd.DataFrame, scenario: Dict[str, Any]) -> pd.DataFrame:
+    Hz = int(scenario["horizon"])
+    all_targets = sorted(irf_df["target"].unique().tolist())
+    chosen_targets = _filter_targets(all_targets, scenario.get("targets", {}))
+
+    profiles = {s["var"]: s["impulse"] for s in scenario["shocks"]}
+
+    rows: List[Dict[str, Any]] = []
+    for tgt in chosen_targets:
+        agg = np.zeros(Hz + 1)
+        contribs: Dict[str, np.ndarray] = {}
+        for sh, prof in profiles.items():
+            F = irf_df[(irf_df["shock"] == sh) & (irf_df["target"] == tgt)]
+            if F.empty:
+                continue
+            vec = np.zeros(Hz + 1)
+            for _, r in F.iterrows():
+                h = int(r["h"])
+                if 0 <= h <= Hz:
+                    vec[h] = float(r["resp"])
+            eff = np.convolve(prof, vec)[: Hz + 1]
+            agg += eff
+            contribs[sh] = eff
+        for h in range(Hz + 1):
+            rows.append({"target": tgt, "h": h, "effect": float(agg[h]), "source": "mix"})
+        for sh, eff in contribs.items():
+            for h in range(Hz + 1):
+                rows.append({"target": tgt, "h": h, "effect": float(eff[h]), "source": sh})
+    return pd.DataFrame(rows)
+
+
+def summarize_effects(eff_df: pd.DataFrame, horizon_pick: int = 4) -> pd.DataFrame:
+    d = eff_df[(eff_df["h"] == horizon_pick) & (eff_df["source"] == "mix")].copy()
+    d["abs"] = d["effect"].abs()
+    d = d.sort_values("abs", ascending=False)
+    return d[["target", "effect"]]

--- a/src/scenario_post.py
+++ b/src/scenario_post.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pandas as pd
+
+SECTIONS = {
+    "Economy": ["macro.", "gdp", "cpi", "ppi", "trade", "fx", "population"],
+    "Corporate": ["firm.", "employment", "wage", "sales", "capex", "industry"],
+    "Finance": ["policy_rate", "m2", "credit", "spread", "loan_to_deposit", "bank_loan", "npl"],
+    "Investment": ["asset.", "etf", "reits", "bond", "gold"],
+    "Real Estate": ["real_estate.", "housing", "rent", "construction", "permit"],
+    "Debt": ["debt", "dsr", "dti", "leverage", "npl"],
+    "Growth": ["potential", "tfp", "productivity", "growth", "income", "consumption", "saving", "participation"],
+    "Assets": ["asset.", "fx.", "commodity.", "bond.", "equity."],
+}
+
+
+def route_section(name: str) -> str:
+    n = name.lower()
+    for sec, keys in SECTIONS.items():
+        if any(n.startswith(k) or (k in n) for k in keys):
+            return sec
+    return "Assets"
+
+
+def sectionize(eff_df: pd.DataFrame, h_pick: int = 4) -> dict:
+    mix = eff_df[(eff_df["h"] == h_pick) & (eff_df["source"] == "mix")].copy()
+    mix["section"] = mix["target"].map(route_section)
+    out: dict[str, pd.DataFrame] = {}
+    for sec, grp in mix.groupby("section"):
+        out[sec] = grp[["target", "effect"]].sort_values("effect", key=lambda s: s.abs(), ascending=False)
+    return out
+
+
+def render_markdown(name: str, summary_at_h: int, section_maps: dict) -> str:
+    lines = [f"# Scenario: {name}", f"_Summary @h={summary_at_h}_", ""]
+    for sec in [
+        "Economy",
+        "Corporate",
+        "Finance",
+        "Real Estate",
+        "Debt",
+        "Growth",
+        "Investment",
+        "Assets",
+    ]:
+        lines.append(f"## {sec}")
+        df = section_maps.get(sec)
+        if df is None or df.empty:
+            lines.append("- (no material effect)")
+        else:
+            top = df.head(12)
+            for _, r in top.iterrows():
+                lines.append(f"- {r['target']}: {r['effect']:.3f}")
+        lines.append("")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add scenario examples demonstrating step, pulse, gradual, and path shocks
- implement scenario DSL validation, IRF application, and markdown reporting helpers
- replace step 5 runner with orchestration over new scenario modules
- build step 6 final report loaders, analytics, rendering utilities, and CLI orchestration

## Testing
- python -m compileall run_step6_report.py src/report6_*.py

------
https://chatgpt.com/codex/tasks/task_e_68d3bcb38008832d9c2ab11ce5653769