### PR TITLE
Fix KOSIS list parameter keys and update catalog fallbacks

### DIFF
--- a/run_build_catalog.py
+++ b/run_build_catalog.py
@@ -9,10 +9,8 @@ from src.kosis_api import list_stats
 
 # 기본 폴백 후보 (빠른 재시도)
 FALLBACKS = [
-    ("MT_ZTITLE", ["ROOT", "A", "B", "0"]),
-    ("MT_GTITLE", ["ROOT", "A", "B", "0"]),
-    ("MT_ZTITLE", ["AA", "AB", "AC", "A1", "A2"]),
-    ("MT_GTITLE", ["AA", "AB", "AC", "A1", "A2"]),
+    ("MT_ZTITLE", ["A", "ROOT", "0"]),
+    ("MT_OTITLE", ["A", "ROOT", "0"]),
 ]
 
 def _chunks(it: Iterable[str], n: int) -> Iterable[List[str]]:
@@ -86,7 +84,7 @@ def try_build(vwcd: str, roots: list[str], max_depth: int) -> pd.DataFrame:
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--vwcd", default="MT_ZTITLE", help="MT_ZTITLE=주제별, MT_GTITLE=기관별")
+    ap.add_argument("--vwcd", default="MT_ZTITLE", help="MT_ZTITLE=주제별, MT_OTITLE=기관별")
     ap.add_argument("--roots", nargs="+", required=True, help="parentListId 루트들")
     ap.add_argument("--out", default="series_catalog.csv")
     ap.add_argument("--max-depth", type=int, default=6)
@@ -118,7 +116,7 @@ def main():
     # 2) 그래도 실패면 auto-discover로 루트 탐색
     if (df is None or df.empty) and args.auto_discover:
         vw, roots = auto_discover_roots(
-            vwcds=["MT_ZTITLE","MT_GTITLE"],
+            vwcds=["MT_ZTITLE", "MT_OTITLE"],
             max_tries=args.discover_max_tries,
             time_budget=args.discover_time_budget,
             rate_sleep=0.35

--- a/src/catalog.py
+++ b/src/catalog.py
@@ -7,24 +7,24 @@ from typing import Any, Iterable, List
 from .kosis_api import list_stats
 
 
-def harvest_children(vw_cd: str, parent_list_id: str) -> List[dict[str, Any]]:
+def harvest_children(vw_cd: str, parent_id: str) -> List[dict[str, Any]]:
     """Return child statistics list entries for the given parent identifier."""
 
-    payload = list_stats(vw_cd=vw_cd, parent_list_id=parent_list_id)
+    payload = list_stats(vw_cd=vw_cd, parent_id=parent_id)
     return [entry for entry in payload if isinstance(entry, dict)]
 
 
-def walk_catalog(vw_cd: str, parent_list_id: str, depth: int = 1) -> Iterable[dict[str, Any]]:
+def walk_catalog(vw_cd: str, parent_id: str, depth: int = 1) -> Iterable[dict[str, Any]]:
     """Naïve recursive walk over the statistics list tree.
 
     This is intentionally lightweight: production code can expand it to
     respect the KOSIS guide paging rules or enrich metadata.
     """
 
-    queue = [(parent_list_id, 0)]
+    queue = [(parent_id, 0)]
     while queue:
         node_id, level = queue.pop(0)
-        children = harvest_children(vw_cd=vw_cd, parent_list_id=node_id)
+        children = harvest_children(vw_cd=vw_cd, parent_id=node_id)
         for child in children:
             yield child
             if level + 1 < depth and child.get("listId"):

--- a/src/catalog_builder.py
+++ b/src/catalog_builder.py
@@ -20,14 +20,14 @@ def _is_leaf(node: Dict) -> bool:
 
 def _collect_from_root(
     vw_cd: str,
-    root_id: str,
+    parent_id: str,
     max_depth: int,
     depth: int = 0,
 ) -> List[Dict]:
     if depth > max_depth:
         return []
 
-    items = list_stats(vw_cd, root_id)
+    items = list_stats(vw_cd, parent_id)
     collected: List[Dict] = []
     for item in items:
         if _is_leaf(item):
@@ -54,9 +54,9 @@ def build_catalog(vw_cd: str, roots: List[str], max_depth: int = 6) -> pd.DataFr
     """Traverse the statistics list tree and collect candidate tables."""
 
     rows: List[Dict] = []
-    for root in roots:
+    for parent_id in roots:
         try:
-            rows.extend(_collect_from_root(vw_cd, root, max_depth))
+            rows.extend(_collect_from_root(vw_cd, parent_id, max_depth))
         except Exception:
             # Skip problematic roots but continue scanning the others.
             continue

--- a/src/kosis_api.py
+++ b/src/kosis_api.py
@@ -10,7 +10,7 @@ from .utils import get_json
 
 def list_stats(
     vw_cd: str,
-    parent_list_id: str,
+    parent_id: str,
     pindex: int = 1,
     psize: int = 1000,
 ) -> List[Dict[str, Any]]:
@@ -23,12 +23,14 @@ def list_stats(
     """
 
     params = {
-        "serviceKey": KOSIS_API_KEY,
-        "vwCd": vw_cd,
-        "parentListId": parent_list_id,
+        "method": "getList",
         "format": "json",
+        "apiKey": KOSIS_API_KEY,
+        "vwCd": vw_cd,
+        "parentId": parent_id,
         "pIndex": str(pindex),
         "pSize": str(psize),
+        "jsonVD": "Y",
     }
 
     rows = get_json(URL_LIST, params)


### PR DESCRIPTION
## Summary
- align the list API helper with the documented KOSIS parameter names and include the required method/format fields
- keep the catalog traversal logic while switching the parent identifier naming to `parentId`
- update the catalog builder fallback lists to prioritise the `A` root and use the MT_OTITLE view for organisations

## Testing
- python -m compileall src run_build_catalog.py

------
https://chatgpt.com/codex/tasks/task_e_68d3dd1dbd6c832dad2cea1bbbbf2d7d