### PR TITLE
Improve catalog build robustness and logging

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -37,13 +37,15 @@ if __name__ == "__main__":
     step1 = [
         PY, "run_build_catalog.py",
         "--vwcd", "MT_ZTITLE",
-        "--roots", "A1", "A2",
+        "--roots", "A",
         "--out", "series_catalog.csv",
         "--max-depth", "6",
         "--auto-fallback",
         "--auto-discover",
         "--discover-max-tries", "500",
-        "--discover-time-budget", "90"
+        "--discover-time-budget", "90",
+        "--leaf-cap", "400",
+        "--verbose",
     ]
     rc = run(step1)
 

--- a/src/config.py
+++ b/src/config.py
@@ -15,8 +15,8 @@ KOSIS_API_KEY = os.getenv("KOSIS_API_KEY", "")
 DB_PATH       = os.getenv("KOSIS_DB", "kosis.duckdb")
 
 # -------- 호출 설정 --------
-TIMEOUT     = 30
-MAX_RETRIES = 4
+TIMEOUT     = 20
+MAX_RETRIES = 3
 RATE_SLEEP  = 0.35  # 초/호출 (429 뜨면 0.6으로)
 
 # -------- KOSIS 엔드포인트 --------


### PR DESCRIPTION
## Summary
- add deterministic timeout/retry settings and surface verbose HTTP logging utilities
- fix KOSIS list API parameter usage and enhance catalog traversal with logging plus a leaf cap
- expose verbose/leaf-cap controls on catalog builders and update pipeline defaults

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d3e19af284832db6b6104e160b7fc2