### PR TITLE
Enhance catalog build options and API safety

### DIFF
--- a/src/catalog_builder.py
+++ b/src/catalog_builder.py
@@ -10,14 +10,29 @@ from .kosis_api import list_stats
 
 
 def _is_leaf(node: Dict) -> bool:
-    tbl = node.get("TBL_ID") or node.get("tblId") or node.get("tbl_id")
+    tbl = (
+        node.get("TBL_ID")
+        or node.get("tblId")
+        or node.get("tbl_id")
+        or node.get("STATBL_ID")
+        or node.get("statblId")
+    )
     se = (node.get("LIST_SE") or node.get("listSe") or "").upper()
     return bool(tbl) or se in {"TBL", "DT", "TB", "STAT", "TABLE"}
 
 
+def _child_id(node: Dict) -> str | None:
+    return (
+        node.get("LIST_ID")
+        or node.get("listId")
+        or node.get("LIST_CD")
+        or node.get("listCd")
+    )
+
+
 def _norm(node: Dict) -> Dict:
     return {
-        "listId": node.get("LIST_ID") or node.get("listId"),
+        "listId": _child_id(node),
         "orgId": node.get("ORG_ID") or node.get("orgId"),
         "tblId": node.get("TBL_ID") or node.get("tblId"),
         "listSe": (node.get("LIST_SE") or node.get("listSe") or "").upper(),
@@ -41,26 +56,33 @@ def _collect_from_root(
         acc = []
     if depth > max_depth or (leaf_cap and len(acc) >= leaf_cap):
         return acc
-    rows = list_stats(vw_cd, root_id, verbose=verbose)
+    rows = list_stats(vw_cd, root_id, verbose=verbose) or []
     if verbose:
         print(f"[tree] depth={depth} root={root_id} rows={len(rows)} acc={len(acc)}")
     for row in rows:
         if leaf_cap and len(acc) >= leaf_cap:
-            break
+            return acc
         if _is_leaf(row):
             acc.append(_norm(row))
+            if leaf_cap and len(acc) >= leaf_cap:
+                if verbose:
+                    print(f"[catalog] leaf-cap reached: {len(acc)}")
+                return acc
         else:
-            child = row.get("LIST_ID") or row.get("listId")
-            if child:
-                _collect_from_root(
-                    vw_cd,
-                    child,
-                    max_depth,
-                    verbose,
-                    leaf_cap,
-                    depth + 1,
-                    acc,
-                )
+            child = _child_id(row)
+            if not child:
+                continue
+            _collect_from_root(
+                vw_cd,
+                child,
+                max_depth,
+                verbose,
+                leaf_cap,
+                depth + 1,
+                acc,
+            )
+            if leaf_cap and len(acc) >= leaf_cap:
+                return acc
     return acc
 
 
@@ -69,7 +91,7 @@ def build_catalog(
     roots: List[str],
     max_depth: int = 6,
     verbose: bool = False,
-    leaf_cap: int = 500,
+    leaf_cap: int = 5000,
 ) -> pd.DataFrame:
     acc: List[Dict] = []
     for root in roots:

--- a/src/kosis_api.py
+++ b/src/kosis_api.py
@@ -27,15 +27,19 @@ def list_stats(
         "method": "getList",
         "format": "json",
         "content": "json",
+        "jsonVD": "Y",
         "apiKey": KOSIS_API_KEY,
         "vwCd": vw_cd,
         "parentId": parent_id,
-        "pIndex": str(pindex),
-        "pSize": str(psize),
-        "jsonVD": "Y",
+        "pIndex": str(pindex or 1),
+        "pSize": str(psize or 1000),
+    }
+    headers = {
+        "Accept": "application/json,text/plain,*/*",
+        "User-Agent": "kosis-catalog/1.0",
     }
 
-    rows = get_json(URL_LIST, params, verbose=verbose)
+    rows = get_json(URL_LIST, params, headers=headers, verbose=verbose)
     if isinstance(rows, dict) and "list" in rows:
         rows = rows["list"]
     return rows if isinstance(rows, list) else []

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,11 +12,19 @@ import requests
 from .config import MAX_RETRIES, RATE_SLEEP, TIMEOUT
 
 
-def get_json(url: str, params: dict[str, Any], *, verbose: bool = False) -> Any:
+def get_json(
+    url: str,
+    params: dict[str, Any],
+    *,
+    headers: dict[str, str] | None = None,
+    verbose: bool = False,
+) -> Any:
     """Perform a GET request with retry/backoff logic and KOSIS specific guards."""
 
     last_err: Exception | None = None
-    headers = {"Accept": "application/json"}
+    request_headers = {"Accept": "application/json"}
+    if headers:
+        request_headers.update(headers)
     for attempt in range(1, MAX_RETRIES + 1):
         started = time.time()
         try:
@@ -28,7 +36,7 @@ def get_json(url: str, params: dict[str, Any], *, verbose: bool = False) -> Any:
                 )
 
             response = requests.get(
-                url, params=params, timeout=TIMEOUT, headers=headers
+                url, params=params, timeout=TIMEOUT, headers=request_headers
             )
             if verbose:
                 elapsed = time.time() - started


### PR DESCRIPTION
## Summary
- add root autoloading, probe mode, and higher defaults to `run_build_catalog.py`
- improve leaf detection, child traversal, and leaf-cap enforcement in the catalog builder
- harden KOSIS list API calls with explicit headers/params and allow custom headers in the HTTP helper

## Testing
- python run_build_catalog.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d3ea4132d4832db1fcc9230f22ed73