### PR TITLE
Refine KOSIS API wrappers and batch runners

### DIFF
--- a/run_build_catalog.py
+++ b/run_build_catalog.py
@@ -1,62 +1,63 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
-import sys, os
-import argparse
+import os, argparse
 
-# 기존 import 유지
-# from src.catalog_builder import build_catalog  # direct/discover용
-# from src.direct_catalog import run_direct_catalog  # 있으면 사용
-# userstats 추가:
-from src.userstats_runner import run_userstats_batch
 
 def parse_args(argv=None):
     p = argparse.ArgumentParser()
-    p.add_argument("--mode", choices=["direct","discover","userstats"], default=os.getenv("KOSIS_MODE", "direct"))
+    p.add_argument(
+        "--mode",
+        choices=["userstats", "direct", "discover"],
+        default=os.getenv("KOSIS_MODE", "userstats"),
+    )
     p.add_argument("--vwcd", default=os.getenv("KOSIS_VWCD", "MT_ZTITLE"))
     p.add_argument("--roots", nargs="*", default=[os.getenv("KOSIS_ROOTS", "AUTO")])
     p.add_argument("--out", default=os.getenv("KOSIS_OUT", "series_catalog.csv"))
-    p.add_argument("--max-depth", type=int, default=int(os.getenv("KOSIS_MAX_DEPTH", "4")))
+    p.add_argument("--max-depth", type=int, default=int(os.getenv("KOSIS_MAX_DEPTH", "5")))
     p.add_argument("--leaf-cap", type=int, default=int(os.getenv("KOSIS_LEAF_CAP", "5000")))
     p.add_argument("--probe", action="store_true")
     p.add_argument("--verbose", action="store_true")
     # userstats 전용
-    p.add_argument("--userstats", nargs="*", default=None, help="파일 경로 또는 userStatsId 나열")
+    p.add_argument("--userstats", nargs="*", default=None)
     p.add_argument("--prdSe", default=os.getenv("KOSIS_PRDSE", None))
     p.add_argument("--start", dest="startPrdDe", default=os.getenv("KOSIS_START", None))
     p.add_argument("--end", dest="endPrdDe", default=os.getenv("KOSIS_END", None))
     return p.parse_args(argv)
 
+
 def main(argv=None):
     args = parse_args(argv)
-
     if args.mode == "userstats":
+        from src.userstats_runner import run_userstats_batch
+
         if args.verbose:
             print("[build] mode=userstats")
         return run_userstats_batch(
-            userstats_args=args.userstats,
+            args.userstats,
             out=args.out,
             verbose=args.verbose,
             prdSe=args.prdSe,
             startPrdDe=args.startPrdDe,
             endPrdDe=args.endPrdDe,
         )
-
     if args.mode == "direct":
-        # 기존 direct 카탈로그 실행부(이미 있으면 유지)
         from src.direct_catalog import run_direct_catalog
+
+        if args.verbose:
+            print("[build] mode=direct")
         return run_direct_catalog(
-            vwcd=args.vwcd,
-            roots=args.roots,
-            out=args.out,
+            args.vwcd,
+            args.roots,
+            args.out,
             max_depth=args.max_depth,
             verbose=args.verbose,
         )
-
-    # fallback discover (필요 시)
     from src.catalog_builder import build_catalog
-    df = build_catalog(
-        vwcd=args.vwcd,
-        roots=args.roots,
+
+    if args.verbose:
+        print("[build] mode=discover")
+    build_catalog(
+        args.vwcd,
+        args.roots,
         out=args.out,
         max_depth=args.max_depth,
         verbose=args.verbose,
@@ -65,5 +66,7 @@ def main(argv=None):
     )
     return 0
 
+
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/src/catalog.py
+++ b/src/catalog.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Iterable, List
 
-from .kosis_api import list_stats
+from .kosis_api import list_nodes
 
 
 def harvest_children(vw_cd: str, parent_id: str) -> List[dict[str, Any]]:
     """Return child statistics list entries for the given parent identifier."""
 
-    payload = list_stats(vw_cd=vw_cd, parent_id=parent_id)
+    payload = list_nodes(vwCd=vw_cd, parentId=parent_id)
     return [entry for entry in payload if isinstance(entry, dict)]
 
 

--- a/src/catalog_builder.py
+++ b/src/catalog_builder.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 import pandas as pd
 
-from .kosis_api import list_stats
+from .kosis_api import list_nodes
 
 
 def _is_leaf(node: Dict) -> bool:
@@ -56,7 +56,7 @@ def _collect_from_root(
         acc = []
     if depth > max_depth or (leaf_cap and len(acc) >= leaf_cap):
         return acc
-    rows = list_stats(vw_cd, root_id, verbose=verbose) or []
+    rows = list_nodes(vwCd=vw_cd, parentId=root_id, verbose=verbose) or []
     if verbose:
         print(f"[tree] depth={depth} root={root_id} rows={len(rows)} acc={len(acc)}")
     for row in rows:
@@ -89,6 +89,8 @@ def _collect_from_root(
 def build_catalog(
     vw_cd: str,
     roots: List[str],
+    *,
+    out: str | None = None,
     max_depth: int = 6,
     verbose: bool = False,
     leaf_cap: int = 5000,
@@ -101,6 +103,8 @@ def build_catalog(
         if leaf_cap and len(acc) >= leaf_cap:
             break
     df = pd.DataFrame(acc).dropna(subset=["tblId"]).drop_duplicates()
+    if out:
+        df.to_csv(out, index=False, encoding="utf-8")
     if verbose:
         print(f"[tree] collected leaves={len(df)}")
     return df

--- a/src/direct_catalog.py
+++ b/src/direct_catalog.py
@@ -1,22 +1,18 @@
-"""Helpers for the catalogue direct-collection mode.
-
-The direct mode walks the category hierarchy via ``statisticsList`` calls and
-collects table identifiers (``TBL_ID``) without performing the expensive
-depth-first traversal used by the legacy discover mode.
-"""
-
 from __future__ import annotations
 
-import csv
-import os
-from typing import Iterable
+from typing import Dict, List, Set
 
-from .kosis_api import list_stats
+from .kosis_api import list_nodes
 
 LEAF_SE = {"TBL", "DT", "TB", "STAT", "TABLE"}
+VW_MAP = {"SUBJ": "MT_ZTITLE", "ORG": "MT_OTITLE"}
 
 
-def _leaf_tbl_id(node: dict) -> str | None:
+def _se(node: Dict) -> str:
+    return (node.get("LIST_SE") or node.get("listSe") or "").upper()
+
+
+def _tbl(node: Dict):
     return (
         node.get("TBL_ID")
         or node.get("tblId")
@@ -25,7 +21,7 @@ def _leaf_tbl_id(node: dict) -> str | None:
     )
 
 
-def _child_id(node: dict) -> str | None:
+def _child(node: Dict):
     return (
         node.get("LIST_ID")
         or node.get("listId")
@@ -34,16 +30,11 @@ def _child_id(node: dict) -> str | None:
     )
 
 
-def _is_leaf(node: dict) -> bool:
-    se = (node.get("LIST_SE") or node.get("listSe") or "").upper()
-    return bool(_leaf_tbl_id(node)) or (se in LEAF_SE)
-
-
-def _autoload_roots(vwcd: str, parent: str = "A", verbose: bool = False) -> list[str]:
-    rows = list_stats(vwcd, parent, verbose=verbose) or []
-    roots: list[str] = []
+def _roots_autoload(vwcd: str, parent: str = "A", verbose: bool = False) -> List[str]:
+    rows = list_nodes(vwcd, parent, verbose=verbose) or []
+    roots: List[str] = []
     for row in rows:
-        child = _child_id(row)
+        child = _child(row)
         if child:
             roots.append(child)
     if verbose:
@@ -51,71 +42,80 @@ def _autoload_roots(vwcd: str, parent: str = "A", verbose: bool = False) -> list
     return roots
 
 
-def _ensure_iterable(roots: Iterable[str] | None) -> list[str]:
-    if not roots:
-        return []
-    if isinstance(roots, (list, tuple, set)):
-        return list(roots)
-    return [roots]  # type: ignore[list-item]
-
-
 def run_direct_catalog(
-    *,
     vwcd: str,
-    roots: Iterable[str] | None,
-    out: str | None,
-    max_depth: int = 4,
+    roots: List[str],
+    out: str,
+    max_depth: int = 5,
     verbose: bool = False,
-) -> None:
-    roots_list = _ensure_iterable(roots)
-    if roots_list and len(roots_list) == 1 and roots_list[0].upper() in {"AUTO", "TOP"}:
-        roots_list = _autoload_roots(vwcd, "A", verbose) or ["A"]
-    elif not roots_list:
-        roots_list = _autoload_roots(vwcd, "A", verbose) or ["A"]
+):
+    if roots and len(roots) == 1 and roots[0].upper() in ("AUTO", "TOP"):
+        roots = _roots_autoload(vwcd, "A", verbose) or ["A"]
 
-    seen: set[str] = set()
-    tbl_rows: list[dict[str, str | int | None]] = []
+    seen: Set[str] = set()
+    tbl_rows: List[Dict] = []
+    noleaf_streak = 0
+    MAX_NOLEAF_STREAK = 100
 
-    def dfs(node: str, depth: int) -> None:
+    def dfs(node: str, depth: int, vw: str):
+        nonlocal noleaf_streak
         if depth > max_depth:
             return
-        rows = list_stats(vwcd, node, verbose=verbose) or []
+        rows = list_nodes(vw, node, verbose=verbose) or []
+        hit = 0
         for row in rows:
-            if _is_leaf(row):
-                tbl = _leaf_tbl_id(row)
+            if _tbl(row) or _se(row) in LEAF_SE:
+                tbl = _tbl(row)
                 if not tbl:
                     continue
                 if tbl in seen:
                     continue
                 seen.add(tbl)
+                hit += 1
                 tbl_rows.append(
                     {
                         "orgId": row.get("ORG_ID") or row.get("orgId"),
                         "tblId": tbl,
                         "tblNm": row.get("TBL_NM") or row.get("tblNm"),
-                        "pathParent": node,
+                        "vwCd": vw,
+                        "parent": node,
                         "depth": depth,
                     }
                 )
             else:
-                child = _child_id(row)
-                if child:
-                    dfs(child, depth + 1)
+                child = _child(row)
+                if not child:
+                    continue
+                se = _se(row)
+                next_vw = VW_MAP.get(se, vw)
+                if verbose and next_vw != vw:
+                    print(f"[view] switch {vw} -> {next_vw} at node={child} (se={se})")
+                dfs(child, depth + 1, next_vw)
+        if hit == 0:
+            noleaf_streak += 1
+            if verbose and (noleaf_streak % 25 == 0):
+                print(f"[diag] no-leaf streak={noleaf_streak} at node={node} vwCd={vw}")
+            if noleaf_streak >= MAX_NOLEAF_STREAK:
+                if verbose:
+                    print("[stop] early stop by no-leaf streak")
+                return
+        else:
+            noleaf_streak = 0
 
-    for root in roots_list:
-        dfs(root, 1)
+    for root in roots:
+        dfs(root, 1, vwcd)
 
     if out:
-        directory = os.path.dirname(out) or "."
-        os.makedirs(directory, exist_ok=True)
+        import csv
+        import os
+
+        os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
         with open(out, "w", newline="", encoding="utf-8") as fh:
             writer = csv.DictWriter(
-                fh, fieldnames=["orgId", "tblId", "tblNm", "pathParent", "depth"]
+                fh, fieldnames=["orgId", "tblId", "tblNm", "vwCd", "parent", "depth"]
             )
             writer.writeheader()
-            for row in tbl_rows:
-                writer.writerow(row)
-
-    if verbose:
-        print(f"[direct] collected TBL count={len(tbl_rows)}; saved={bool(out)}")
+            writer.writerows(tbl_rows)
+        if verbose:
+            print(f"[direct] collected TBL={len(tbl_rows)} saved={out}")
 

--- a/src/kosis_api.py
+++ b/src/kosis_api.py
@@ -2,30 +2,37 @@
 
 from __future__ import annotations
 
-import os
-import time
 from typing import Any, Dict, List, Optional
 
-import requests
+__all__ = [
+    "list_nodes",
+    "get_param",
+    "get_stat_data",
+    "fetch_userstats",
+]
 
-from .config import KOSIS_API_KEY, URL_DATA, URL_LIST, URL_META, URL_PARAM
-from .utils import get_json
 
-COMMON_PARAMS = {"format": "json", "jsonVD": "Y", "content": "json"}
+# [ANCHOR:KOSIS_API_CONSTS]
+_STAT_LIST_URL = "https://kosis.kr/openapi/statisticsList.do"
+_STAT_DATA_URL = "https://kosis.kr/openapi/statisticsData.do"
+_STAT_PARAM_URL = "https://kosis.kr/openapi/Param/statisticsParameterData.do"
+_STAT_BIG_URL = "https://kosis.kr/openapi/statisticsBigData.do"
 
-# API 엔드포인트(기존과 동일한 상수 사용 권장)
-_STAT_DATA_URL = URL_DATA
-# 공통 파라미터(이미 있다면 중복 정의 금지)
-_COMMON = COMMON_PARAMS
+_COMMON = {"format": "json", "jsonVD": "Y", "content": "json"}
 
 
 def _get_api_key() -> str:
+    import os
+
     k = os.getenv("KOSIS_API_KEY", "")
-    if not k:
-        k = KOSIS_API_KEY
     if not k:
         raise RuntimeError("KOSIS_API_KEY not set")
     return k
+
+
+# [ANCHOR:KOSIS_API_GETJSON]
+import requests
+import time
 
 
 def _get_json(
@@ -33,9 +40,9 @@ def _get_json(
     params: Dict[str, Any],
     verbose: bool = False,
     timeout: int = 20,
-    retry: int = 2,
+    retry: int = 3,
+    backoff: float = 0.6,
 ):
-    # 간단 리트라이(429/5xx)
     sess = requests.Session()
     last = None
     for t in range(retry + 1):
@@ -46,163 +53,128 @@ def _get_json(
                 timeout=timeout,
                 headers={"Accept": "application/json"},
             )
-            ctype = r.headers.get("Content-Type", "")
             if verbose:
                 print(
                     f"[HTTP] GET {url} try={t+1} timeout={timeout} params={params}"
                 )
                 print(
-                    f"[HTTP] status={r.status_code} ctype={ctype} elapsed={getattr(r, 'elapsed', None)}"
+                    f"[HTTP] status={r.status_code} ctype={r.headers.get('Content-Type','')} elapsed={getattr(r,'elapsed',None)}"
                 )
             r.raise_for_status()
             return r.json()
         except Exception as e:
             last = e
-            # 429/5xx 백오프
-            time.sleep(0.6 + 0.6 * t)
-    raise last
+            time.sleep(backoff * (t + 1))
+    raise last  # type: ignore[misc]
 
 
-def list_stats(
-    vw_cd: str,
-    parent_id: str,
-    pindex: int = 1,
-    psize: int = 1000,
+# [ANCHOR:KOSIS_API_LIST]
+def list_nodes(
+    vwCd: str,
+    parentId: str,
+    pIndex: int = 1,
+    pSize: int = 1000,
     verbose: bool = False,
 ) -> List[Dict[str, Any]]:
-    """Retrieve a statistics list for the provided view and parent list.
-
-    The helper enforces the official parameter names (``apiKey``, ``parentId``
-    etc.) and optionally emits verbose HTTP logging.  Some environments wrap the
-    payload in a top-level ``{"list": [...]}``, so we normalise the response to a
-    plain list for downstream callers.
-    """
-
-    params = {
-        **COMMON_PARAMS,
-        "method": "getList",
-        "apiKey": _get_api_key(),
-        "vwCd": vw_cd,
-        "parentId": parent_id,
-        "pIndex": str(pindex or 1),
-        "pSize": str(psize or 1000),
-    }
-    headers = {
-        "Accept": "application/json,text/plain,*/*",
-        "User-Agent": "kosis-catalog/1.0",
-    }
-
-    rows = get_json(URL_LIST, params, headers=headers, verbose=verbose)
-    if isinstance(rows, dict) and "list" in rows:
-        rows = rows["list"]
-    return rows if isinstance(rows, list) else []
-
-
-def data_by_userstats(
-    user_stats_id: str,
-    prd_se: str,
-    start: Optional[str] = None,
-    end: Optional[str] = None,
-    newEstPrdCnt: Optional[int] = None,
-    prdInterval: Optional[int] = None,
-    outputFields: Optional[str] = None,
-) -> Any:
-    """Retrieve statistics data for the userStatsId style endpoint."""
-
     params: Dict[str, Any] = {
-        **COMMON_PARAMS,
+        **_COMMON,
         "method": "getList",
         "apiKey": _get_api_key(),
-        "userStatsId": user_stats_id,
-        "prdSe": prd_se,
+        "vwCd": vwCd,
+        "parentId": parentId,
+        "pIndex": str(pIndex),
+        "pSize": str(pSize),
     }
-    if start:
-        params["startPrdDe"] = start
-    if end:
-        params["endPrdDe"] = end
-    if newEstPrdCnt:
-        params["newEstPrdCnt"] = newEstPrdCnt
-    if prdInterval:
-        params["prdInterval"] = prdInterval
-    if outputFields:
-        params["outputFields"] = outputFields
-    return get_json(URL_DATA, params)
+    data = _get_json(_STAT_LIST_URL, params, verbose=verbose)
+    if isinstance(data, dict):
+        for key in ("list", "LIST", "rows", "ROW"):
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        for value in data.values():
+            if isinstance(value, list):
+                return value
+        return []
+    return data if isinstance(data, list) else []
 
 
-def data_by_params(
-    org_id: str,
-    tbl_id: str,
-    prd_se: str,
-    obj: Optional[Dict[str, str]],
-    itm_id: str,
-    start: Optional[str] = None,
-    end: Optional[str] = None,
-    newEstPrdCnt: Optional[int] = None,
-    prdInterval: Optional[int] = None,
-    outputFields: str = "PRD_DE,DT,UNIT_NM",
-) -> List[Dict[str, Any]]:
-    """Retrieve statistics data for the parameterised table endpoint."""
-
-    params: Dict[str, Any] = {
-        **COMMON_PARAMS,
-        "method": "getList",
-        "apiKey": _get_api_key(),
-        "orgId": org_id,
-        "tblId": tbl_id,
-        "prdSe": prd_se,
-        "itmId": itm_id,
-    }
-    for key, value in (obj or {}).items():
-        if key.lower().startswith("objl") and value:
-            params[key] = value
-    if start:
-        params["startPrdDe"] = start
-    if end:
-        params["endPrdDe"] = end
-    if newEstPrdCnt:
-        params["newEstPrdCnt"] = newEstPrdCnt
-    if prdInterval:
-        params["prdInterval"] = prdInterval
-    if outputFields:
-        params["outputFields"] = outputFields
-    if not any(key for key in params if key.lower().startswith("objl")):
-        raise ValueError("Param API 호출 시 objL1~objL8 중 최소 1개가 필요합니다.")
-    if not itm_id:
-        raise ValueError("Param API 호출 시 itmId는 필수입니다.")
-    return get_json(URL_PARAM, params)
-
-
-def get_meta_table(org_id: str, tbl_id: str) -> Dict[str, Any]:
-    """Fetch table metadata for the supplied organisation/table identifiers."""
-
+# [ANCHOR:KOSIS_API_PARAM]
+def get_param(orgId: str, tblId: str, verbose: bool = False):
     params = {
-        **COMMON_PARAMS,
-        "method": "getMeta",
+        **_COMMON,
+        "method": "getList",
         "apiKey": _get_api_key(),
-        "type": "TBL",
-        "orgId": org_id,
-        "tblId": tbl_id,
+        "orgId": orgId,
+        "tblId": tblId,
     }
-    return get_json(URL_META, params)
+    return _get_json(_STAT_PARAM_URL, params, verbose=verbose)
 
 
-def fetch_userstats(
-    userStatsId: str,
-    verbose: bool = False,
+# [ANCHOR:KOSIS_API_DATA_URLGEN]
+def get_stat_data(
+    orgId: str,
+    tblId: str,
+    *,
     prdSe: Optional[str] = None,
     startPrdDe: Optional[str] = None,
     endPrdDe: Optional[str] = None,
+    itmId: Optional[str] = None,
+    objL1: Optional[str] = None,
+    objL2: Optional[str] = None,
+    objL3: Optional[str] = None,
+    objL4: Optional[str] = None,
+    verbose: bool = False,
 ) -> List[Dict[str, Any]]:
-    """
-    등록URL(userStatsId)로 통계자료 호출.
-    """
+    params: Dict[str, Any] = {
+        **_COMMON,
+        "method": "getList",
+        "apiKey": _get_api_key(),
+        "orgId": orgId,
+        "tblId": tblId,
+    }
+    if prdSe:
+        params["prdSe"] = prdSe
+    if startPrdDe:
+        params["startPrdDe"] = startPrdDe
+    if endPrdDe:
+        params["endPrdDe"] = endPrdDe
+    if itmId:
+        params["itmId"] = itmId
+    if objL1:
+        params["objL1"] = objL1
+    if objL2:
+        params["objL2"] = objL2
+    if objL3:
+        params["objL3"] = objL3
+    if objL4:
+        params["objL4"] = objL4
+
+    data = _get_json(_STAT_DATA_URL, params, verbose=verbose)
+    if isinstance(data, dict):
+        for key in ("list", "LIST", "rows"):
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        for value in data.values():
+            if isinstance(value, list):
+                return value
+        return []
+    return data if isinstance(data, list) else []
+
+
+# [ANCHOR:KOSIS_API_DATA_USERSTATS]
+def fetch_userstats(
+    userStatsId: str,
+    *,
+    prdSe: Optional[str] = None,
+    startPrdDe: Optional[str] = None,
+    endPrdDe: Optional[str] = None,
+    verbose: bool = False,
+) -> List[Dict[str, Any]]:
     params: Dict[str, Any] = {
         **_COMMON,
         "method": "getList",
         "apiKey": _get_api_key(),
         "userStatsId": userStatsId,
     }
-    # 기간 필터는 제공 시에만 설정
     if prdSe:
         params["prdSe"] = prdSe
     if startPrdDe:
@@ -211,17 +183,13 @@ def fetch_userstats(
         params["endPrdDe"] = endPrdDe
 
     data = _get_json(_STAT_DATA_URL, params, verbose=verbose)
-    # KOSIS는 보통 list/rows 구조 or 바로 배열로 반환
     if isinstance(data, dict):
-        # 가장 가능성 높은 키 추정
-        for k in ("list", "LIST", "data", "DATA", "rows"):
-            if k in data and isinstance(data[k], list):
-                return data[k]
-        # dict인데 리스트를 못 찾으면 항목값을 스캔
-        for v in data.values():
-            if isinstance(v, list):
-                return v
+        for key in ("list", "LIST", "rows"):
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        for value in data.values():
+            if isinstance(value, list):
+                return value
         return []
-    elif isinstance(data, list):
-        return data
-    return []
+    return data if isinstance(data, list) else []
+

--- a/src/userstats_runner.py
+++ b/src/userstats_runner.py
@@ -1,97 +1,88 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
-import os, csv, sys
-from typing import Iterable, List, Dict, Any, Tuple, Optional
+import os, csv, re
+from typing import List, Dict, Any, Optional
+from .kosis_api import fetch_userstats
 
-try:
-    from .kosis_api import fetch_userstats
-except ImportError:
-    # 상대 임포트 보정(직접 실행 대비)
-    from kosis_api import fetch_userstats
+USERSTATS_RE = re.compile(r"^[\w\-]+/\d+/DT_[A-Z0-9_]+/.+$")  # 느슨한 검증
 
 
-def _load_userstats_list(arg_list: Optional[List[str]]) -> List[str]:
-    """
-    arg_list:
-      - ["path/to/file.txt"] → 파일 경로면 줄단위 로드(# 주석, 빈줄 무시)
-      - ["a/b/c", "x/y/z"]  → 직접 나열
-    """
-    if not arg_list:
+def _load_userstats_list(userstats_args: Optional[List[str]]) -> List[str]:
+    if not userstats_args:
         return []
-    if len(arg_list) == 1 and os.path.isfile(arg_list[0]):
-        path = arg_list[0]
-        items: List[str] = []
-        with open(path, "r", encoding="utf-8") as f:
+    # 단일 인자이며 파일처럼 보이면 우선 파일 시도
+    cand = userstats_args[0] if len(userstats_args) == 1 else None
+    items: List[str] = []
+    if cand and (cand.lower().endswith(".txt") or os.path.isfile(cand)) and os.path.isfile(cand):
+        with open(cand, "r", encoding="utf-8") as f:
             for line in f:
                 s = line.strip()
                 if not s or s.startswith("#"):
                     continue
+                if s in {'@"', '"@'} or 'Set-Content' in s:
+                    continue
                 items.append(s)
         return items
-    # 공백/줄바꿈으로 섞여 들어온 경우도 분리
-    items: List[str] = []
-    for v in arg_list:
-        if not v:
-            continue
+    # 직접 나열
+    for v in userstats_args:
         for tok in str(v).replace("\r", "\n").split("\n"):
-            tok = tok.strip()
-            if tok and not tok.startswith("#"):
-                items.append(tok)
+            s = tok.strip()
+            if not s or s.startswith("#"):
+                continue
+            if s in {'@"', '"@'} or 'Set-Content' in s:
+                continue
+            items.append(s)
     return items
 
 
-def _flatten_rows(rows: List[Dict[str, Any]]) -> Tuple[List[str], List[Dict[str, Any]]]:
-    """
-    서로 키가 다른 레코드들을 CSV로 쓰기 위해 헤더를 집합화.
-    """
+def _flatten_rows(rows: List[Dict[str, Any]]):
     keys = set()
     for r in rows:
         keys.update(r.keys())
-    cols = sorted(keys)
-    return cols, rows
+    return sorted(keys), rows
 
 
 def run_userstats_batch(
     userstats_args: Optional[List[str]],
+    *,
     out: Optional[str] = None,
     verbose: bool = False,
-    prdSe: Optional[str] = None,
-    startPrdDe: Optional[str] = None,
-    endPrdDe: Optional[str] = None,
+    prdSe=None,
+    startPrdDe=None,
+    endPrdDe=None,
 ) -> int:
-    us_list = _load_userstats_list(userstats_args)
+    lst = _load_userstats_list(userstats_args)
     if verbose:
-        print(f"[userstats] input count={len(us_list)}")
-
+        print(f"[userstats] input count={len(lst)}")
     all_rows: List[Dict[str, Any]] = []
-    for idx, usid in enumerate(us_list, 1):
+    for i, usid in enumerate(lst, 1):
         if verbose:
-            print(f"[userstats] ({idx}/{len(us_list)}) fetch userStatsId={usid}")
+            print(f"[userstats] ({i}/{len(lst)}) fetch userStatsId={usid}")
         try:
             rows = fetch_userstats(
-                userStatsId=usid,
-                verbose=verbose,
+                usid,
                 prdSe=prdSe,
                 startPrdDe=startPrdDe,
                 endPrdDe=endPrdDe,
+                verbose=verbose,
             ) or []
             for r in rows:
                 r["_userStatsId"] = usid
             all_rows.extend(rows)
         except Exception as e:
-            print(f"[userstats][warn] failed: {usid} err={e}")
-
+            print(f"[userstats][warn] {usid} err={e}")
     if out:
+        import os
+
         os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
-        cols, rows2 = _flatten_rows(all_rows)
+        cols, recs = _flatten_rows(all_rows)
         with open(out, "w", newline="", encoding="utf-8") as f:
             w = csv.DictWriter(f, fieldnames=cols)
             w.writeheader()
-            w.writerows(rows2)
+            w.writerows(recs)
         if verbose:
             print(f"[userstats] saved: {out} rows={len(all_rows)}")
     else:
         if verbose:
             print(f"[userstats] done. rows={len(all_rows)} (no file)")
-
     return 0
+


### PR DESCRIPTION
## Summary
- replace the KOSIS API wrapper with deterministic helper functions for lists, parameters, table data, and user stats
- refresh the user stats batch runner and direct catalog traversal to take advantage of the new API helpers and early-stop safeguards
- streamline the catalog build CLI and run_all entrypoint to prioritise user stats collection and fixed interpreter usage

## Testing
- python -m compileall src run_all.py run_build_catalog.py

------
https://chatgpt.com/codex/tasks/task_e_68d4ae956258832d9ac18b7b308016a4